### PR TITLE
Verify the training artifact at the live evaluation precision

### DIFF
--- a/internal/training/pytorch_worker_test.go
+++ b/internal/training/pytorch_worker_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 OpenWALDO Project contributors
+// Copyright (c) 2026 CtrlIQ, Inc.
+// Copyright (c) 2026 Gregory M. Kurtzer
+// SPDX-License-Identifier: Apache-2.0
+
+package training
+
+import (
+	"regexp"
+	"testing"
+)
+
+// The artifact check in ADR 0044 exists to detect serialization, precision, and
+// loader faults in the persisted weights. It can only measure those if the
+// reloaded model is evaluated exactly as the live model was. Evaluating the two
+// at different compute precisions instead measures autocast rounding, which
+// accumulates with depth until it exceeds the tolerance for every sufficiently
+// large model while revealing nothing about the artifact.
+func TestPyTorchWorkerEvaluatesArtifactAtLiveEvaluationPrecision(t *testing.T) {
+	pattern := regexp.MustCompile(`evaluate_model\([^)]*mixed_precision=(True|False)\)`)
+	matches := pattern.FindAllStringSubmatch(string(pyTorchWorker), -1)
+	if len(matches) < 2 {
+		t.Fatalf("expected the worker to evaluate both the live and reloaded model, found %d call(s)", len(matches))
+	}
+	for _, match := range matches[1:] {
+		if match[1] != matches[0][1] {
+			t.Fatalf("held-out evaluations disagree on compute precision: %q vs %q", matches[0][0], match[0])
+		}
+	}
+}

--- a/internal/training/workers/pytorch.py
+++ b/internal/training/workers/pytorch.py
@@ -726,7 +726,11 @@ class Trainer:
             if missing or unexpected:
                 raise ValueError(f"saved artifact weights do not match architecture: missing={missing}, unexpected={unexpected}")
             artifact_model.to(device=self.device, dtype=torch.float32)
-            artifact_loss = self.evaluate_model(artifact_model, mixed_precision=False)
+            # Evaluate the artifact exactly as the live model was evaluated. Under
+            # a different compute precision this comparison measures autocast
+            # rounding rather than the reload, and that error grows with depth
+            # until it exceeds the tolerance for every sufficiently large model.
+            artifact_loss = self.evaluate_model(artifact_model, mixed_precision=True)
             del artifact_model
             live_loss = self.evaluations[-1]["metrics"]["heldout_loss"]
             tolerance = max(0.02, abs(live_loss) * 0.01)

--- a/testing/e2e/model-mlx.sh
+++ b/testing/e2e/model-mlx.sh
@@ -26,6 +26,8 @@ fi
 
 script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 repo_root=$(CDPATH='' cd -- "$script_dir/../.." && pwd)
+revision=$(sed -n 's/.*MLXRevision = "\(.*\)".*/\1/p' "$repo_root/internal/training/mlx.go")
+[ -n "$revision" ] || { echo "could not read MLXRevision from internal/training/mlx.go" >&2; exit 1; }
 temporary_base=${TMPDIR:-/tmp}
 work=$(mktemp -d "$temporary_base/waldo-mlx-e2e.XXXXXX")
 
@@ -130,7 +132,7 @@ EOF
 
 output=$("$binary" model train mlx-smoke "$compose")
 printf '%s\n' "$output"
-printf '%s\n' "$output" | grep -q 'backend       mlx@builtin-mlx-worker-schema-1-r2'
+printf '%s\n' "$output" | grep -q 'backend       mlx@'"$revision"''
 summary=$("$binary" --json model summary mlx-smoke)
 printf '%s\n' "$summary" | grep -Eq '"simulated"[[:space:]]*:[[:space:]]*false'
 printf '%s\n' "$summary" | grep -Eq '"name"[[:space:]]*:[[:space:]]*"mlx"'
@@ -142,7 +144,7 @@ find "$models/mlx-smoke/runs" -type d -name 'step-*' -exec test -f '{}/model.saf
 
 train_output=$("$binary" model train mlx-smoke core/e2e/mlx --epochs 2)
 printf '%s\n' "$train_output"
-printf '%s\n' "$train_output" | grep -q 'backend       mlx@builtin-mlx-worker-schema-1-r2'
+printf '%s\n' "$train_output" | grep -q 'backend       mlx@'"$revision"''
 summary=$("$binary" --json model summary mlx-smoke)
 printf '%s\n' "$summary" | grep -Eq '"runs"[[:space:]]*:[[:space:]]*\['
 printf '%s\n' "$summary" | grep -Eq '"initialization"[[:space:]]*:'

--- a/testing/e2e/model-pytorch.sh
+++ b/testing/e2e/model-pytorch.sh
@@ -26,6 +26,8 @@ fi
 
 script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 repo_root=$(CDPATH='' cd -- "$script_dir/../.." && pwd)
+revision=$(sed -n 's/.*PyTorchRevision = "\(.*\)".*/\1/p' "$repo_root/internal/training/pytorch.go")
+[ -n "$revision" ] || { echo "could not read PyTorchRevision from internal/training/pytorch.go" >&2; exit 1; }
 temporary_base=${TMPDIR:-/tmp}
 work=$(mktemp -d "$temporary_base/waldo-pytorch-e2e.XXXXXX")
 
@@ -127,13 +129,13 @@ EOF
 
 output=$("$binary" model train pytorch-smoke "$compose")
 printf '%s\n' "$output"
-printf '%s\n' "$output" | grep -q 'backend       pytorch@builtin-pytorch-worker-schema-1-r2'
+printf '%s\n' "$output" | grep -q 'backend       pytorch@'"$revision"''
 summary=$("$binary" --json model summary pytorch-smoke)
 printf '%s\n' "$summary" | grep -Eq '"simulated"[[:space:]]*:[[:space:]]*false'
 printf '%s\n' "$summary" | grep -Eq '"name"[[:space:]]*:[[:space:]]*"pytorch"'
 
 train_output=$("$binary" model train pytorch-smoke core/e2e/pytorch --epochs 2)
-printf '%s\n' "$train_output" | grep -q 'backend       pytorch@builtin-pytorch-worker-schema-1-r2'
+printf '%s\n' "$train_output" | grep -q 'backend       pytorch@'"$revision"''
 run_count=$(find "$models/pytorch-smoke/runs" -type f -name RUN.json -print | wc -l | tr -d ' ')
 [ "$run_count" -eq 2 ] || { echo "found $run_count PyTorch runs, want 2" >&2; exit 1; }
 grep -ERq '"initialization"[[:space:]]*:' "$models/pytorch-smoke/runs" || { echo "continued PyTorch run did not pin initialization" >&2; exit 1; }

--- a/testing/e2e/model-torchtitan.sh
+++ b/testing/e2e/model-torchtitan.sh
@@ -26,6 +26,8 @@ fi
 
 script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 repo_root=$(CDPATH='' cd -- "$script_dir/../.." && pwd)
+revision=$(sed -n 's/.*TorchTitanRevision = "\(.*\)".*/\1/p' "$repo_root/internal/training/torchtitan.go")
+[ -n "$revision" ] || { echo "could not read TorchTitanRevision from internal/training/torchtitan.go" >&2; exit 1; }
 temporary_base=${TMPDIR:-/tmp}
 work=$(mktemp -d "$temporary_base/waldo-torchtitan-e2e.XXXXXX")
 
@@ -113,7 +115,7 @@ EOF
 
 output=$("$binary" model train torchtitan-smoke "$compose")
 printf '%s\n' "$output"
-printf '%s\n' "$output" | grep -q 'backend       torchtitan@builtin-torchtitan-worker-schema-1-r2'
+printf '%s\n' "$output" | grep -q 'backend       torchtitan@'"$revision"''
 summary=$("$binary" --json model summary torchtitan-smoke)
 printf '%s\n' "$summary" | grep -Eq '"simulated"[[:space:]]*:[[:space:]]*false'
 printf '%s\n' "$summary" | grep -Eq '"name"[[:space:]]*:[[:space:]]*"torchtitan"'


### PR DESCRIPTION
## What changed

`waldo model train` cannot complete for any model above roughly 76M parameters, on any GPU. Two commits, kept separate because they are separate bugs, but the first is why the second went unnoticed.

**Verify the training artifact at the live evaluation precision.** ADR 0044's check reloads `model.safetensors` and compares its held-out loss against the live number, failing outside the larger of 0.02 or one percent. The live number is measured under bfloat16 autocast (`record_evaluation` passes `mixed_precision=True`), while the reloaded model is cast to float32 and evaluated with `mixed_precision=False`. The comparison therefore measures autocast rounding rather than the reload. That error accumulates with depth, so it crosses the tolerance at a fixed model size and every larger model then fails verification for a fault it does not have.

The artifact is always *better* than the live model, which is the tell: fp32 evaluation beats bf16 evaluation of the same weights.

Artifact loss delta, same corpus and presets, on one AMD gfx1151 (ROCm 7.13) and one NVIDIA A30 (CUDA 12.8):

| preset | layers / width | before, ROCm | before, CUDA | after, ROCm | after, CUDA |
| --- | --- | --- | --- | --- | --- |
| 10m | 6 / 384 | -0.006949 | -0.006992 | +0.000101 | -0.000005 |
| 35m | 12 / 512 | -0.013628 | -0.013719 | +0.000000 | -0.000039 |
| 90m | 12 / 768 | **-0.021570 fails** | **-0.022532 fails** | +0.000115 | +0.000063 |

Two vendors, two drivers, two PyTorch builds, agreeing to under one percent, which is what you would expect if the cause is arithmetic rather than hardware. After the change the depth dependence is gone rather than merely reduced, and the live held-out losses are identical to six decimals, so training is untouched.

The residual is the bfloat16 weight round-trip the check exists to measure. The previous offset was large enough to hide it: a real serialization fault had to exceed 0.02 *on top of* a systematic -0.0216 before anyone saw it, so the check was failing good models and blind to bad ones at the same time. It now has roughly 170x headroom over its noise floor.

**Derive the expected worker revision in the lifecycle tests.** The MLX, PyTorch and TorchTitan lifecycle tests each assert a hardcoded backend revision of `r2`. Every one of those workers is at `r6`, so all three fail at that assertion on any machine able to run them. The suite still reports green because each skips wherever its runtime is absent and CI runs only `ingest-direct.sh`, which left the real training path with no working coverage.

They now read the revision from the constant the binary reports. Pinning the contract is worth keeping; pinning a *copy* of it is what went stale, and it would go stale again at the next bump — #1 already moves TorchTitan to `r7`.

## Verification

- `gofmt -l .` clean, `go vet ./...` clean, `./testing/all.sh` green on macOS.
- `testing/e2e/model-pytorch.sh` on Linux with real CUDA torch: **exits 1 on `main`** at the `r2` assertion, exits 0 here. Also re-run with the constant set to `r7` to confirm the derived assertion tracks a bump.
- The new guard in `internal/training` was checked against the unfixed worker to confirm it can fail, not just pass:
  ```
  --- FAIL: TestPyTorchWorkerEvaluatesArtifactAtLiveEvaluationPrecision
      held-out evaluations disagree on compute precision:
      "evaluate_model(self.model, mixed_precision=True)" vs
      "evaluate_model(artifact_model, mixed_precision=False)"
  ```
- Full training runs on both accelerators for the three presets above, before and after.

Two limitations worth stating rather than leaving to be found:

The guard is a source-level assertion, not a behavioural one. `model-pytorch.sh` trains a 1-layer, width-32 model, which is far too small to accumulate this error, so an assertion on its recorded delta would pass with or without the bug. That the only real-torch test is too small to catch depth-dependent faults is arguably the more interesting finding, and I did not want to ship a test that cannot fail.

`TestMLXBackendStreamsProtocolAndConsumesCompletion` is flaky under `-race`, failing 5 of 8 runs on **baseline `main`** and 7 of 8 here, with `mlx_test.go:77: MLX worker: read |0: file already closed`. It is unrelated to this change, which touches the PyTorch worker and shell scripts rather than the MLX path, and it appears intermittently in this repo's CI history. Flagging it so it is not misattributed.

## Contracts

No durable format changes and no ADR change. ADR 0044's stated intent is unaffected and better served: the check still verifies that persisted weights reload and retain measured quality, and now measures only that.

## DCO

- [x] Every commit includes a `Signed-off-by` trailer (`git commit --signoff`).
