### PR TITLE
Repair quantized model export on a clean installation

### DIFF
--- a/docs/TRAINING-AND-CALIBRATION.md
+++ b/docs/TRAINING-AND-CALIBRATION.md
@@ -56,7 +56,10 @@ quantizer uses those measurements while encoding the lower-precision release.
 The release records:
 
 - the requested simple quant level and exact llama.cpp recipe;
-- SHA-256, version, and name of the quantizer and calibration executables;
+- SHA-256 and name of the quantizer and calibration executables, plus the
+  version each reports; the version is best effort and is absent when a tool
+  does not implement `--version` or does not answer promptly, so the SHA-256 is
+  what identifies a tool;
 - the source corpus BOM hash and selected index paths;
 - selected shard hashes, budget, seed, record count, and sample hash; and
 - the complete compact calibration evidence embedded in the release

--- a/internal/calibration/calibration.go
+++ b/internal/calibration/calibration.go
@@ -84,6 +84,10 @@ func Prepare(ctx context.Context, source corpus.BOM, cache *lookaside.Cache, bud
 	if err != nil {
 		return Prepared{}, err
 	}
+	// MkdirTemp requires its parent to exist.
+	if err := cache.EnsureScratch(); err != nil {
+		return Prepared{}, fmt.Errorf("prepare calibration scratch %s: %w; set a writable location with `waldo config set lookaside.scratch <directory>`", cache.Scratch(), err)
+	}
 	directory, err := os.MkdirTemp(cache.Scratch(), ".waldo-calibration-*")
 	if err != nil {
 		return Prepared{}, err

--- a/internal/calibration/calibration_test.go
+++ b/internal/calibration/calibration_test.go
@@ -146,3 +146,24 @@ func calibrationCorpus(object, objectSHA string, objectBytes, tokens, records in
 	pin := corpus.ShardPin{Manifest: manifest.Path, URL: object, SHA256: objectSHA, Format: "parquet", RecordSchema: shard.TextRecordSchema, License: "CC0-1.0", ConvertedBy: conversion, Docs: records, Tokens: tokens, Bytes: objectBytes, Assessment: assessment, Redaction: redaction}
 	return corpus.BOM{Kind: "openwaldo-bom", Schema: 1, Subject: "corpus", Paths: []string{"core/test"}, Manifests: []corpus.ManifestPin{manifest}, Shards: []corpus.ShardPin{pin}, Totals: measure, Licenses: licenses}
 }
+
+func TestPrepareCreatesMissingScratchRoot(t *testing.T) {
+	object, objectSHA, objectBytes, referenceTokens := calibrationShard(t, []string{"alpha", "bravo", "charlie"})
+	absent := filepath.Join(t.TempDir(), "never-created")
+	cache, err := lookaside.NewCache(absent, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := Prepare(context.Background(), calibrationCorpus(object, objectSHA, objectBytes, referenceTokens, 3), cache, 8, 42, nil)
+	if err != nil {
+		t.Fatalf("calibration failed on a scratch root that did not exist yet: %v", err)
+	}
+	defer prepared.Cleanup()
+	info, err := os.Stat(cache.Scratch())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o700 {
+		t.Fatalf("scratch root mode = %04o, want 0700 to match the lookaside cache", mode)
+	}
+}

--- a/internal/cli/model.go
+++ b/internal/cli/model.go
@@ -629,19 +629,19 @@ func runModelTrainWorker(commandContext Context, _ []string, stdout, stderr io.W
 	if err != nil {
 		return err
 	}
-	scratchRoot, err := config.EffectiveScratchRoot(configuration)
-	if err != nil {
-		return err
-	}
-	scratch := filepath.Join(scratchRoot, "train-worker", cluster.RendezvousID, fmt.Sprintf("node-%d", cluster.NodeRank))
-	if err := os.MkdirAll(scratch, 0o755); err != nil {
-		return err
-	}
-	defer os.RemoveAll(scratch)
 	cache, err := lookaside.DefaultCache()
 	if err != nil {
 		return err
 	}
+	// The cache owns the scratch root, including its mode.
+	if err := cache.EnsureScratch(); err != nil {
+		return err
+	}
+	scratch := filepath.Join(cache.Scratch(), "train-worker", cluster.RendezvousID, fmt.Sprintf("node-%d", cluster.NodeRank))
+	if err := os.MkdirAll(scratch, 0o700); err != nil {
+		return err
+	}
+	defer os.RemoveAll(scratch)
 	run := func(runCluster training.Cluster, request training.Request) error {
 		return training.RunSecondaryTorchTitan(commandContext.Execution, runCluster, request)
 	}
@@ -666,7 +666,7 @@ func runSecondaryStages(commandContext Context, cluster training.Cluster, modelR
 			return fmt.Errorf("primary published a %d-node run but this worker was started with --nodes %d; every node must agree on the topology", plan.Nodes, cluster.Nodes)
 		}
 		stageScratch := filepath.Join(scratch, plan.RunID)
-		if err := os.MkdirAll(stageScratch, 0o755); err != nil {
+		if err := os.MkdirAll(stageScratch, 0o700); err != nil {
 			return err
 		}
 		request, err := secondaryTrainingRequest(commandContext, plan, modelRoot, cache, stageScratch, stderr)

--- a/internal/lookaside/cache.go
+++ b/internal/lookaside/cache.go
@@ -112,6 +112,16 @@ func DefaultCache() (*Cache, error) {
 
 func (cache *Cache) Root() string    { return cache.root }
 func (cache *Cache) Scratch() string { return cache.scratch }
+
+// EnsureScratch creates the scratch root and holds it at 0700. MkdirAll applies
+// its mode only on creation, so a root left wider by an older command is
+// corrected rather than inherited.
+func (cache *Cache) EnsureScratch() error {
+	if err := os.MkdirAll(cache.scratch, 0o700); err != nil {
+		return err
+	}
+	return os.Chmod(cache.scratch, 0o700)
+}
 func (cache *Cache) MaxBytes() int64 { return cache.maxBytes }
 func (cache *Cache) Retained() bool  { return cache.retain }
 
@@ -352,7 +362,7 @@ func (cache *Cache) fetchCandidate(ctx context.Context, objectURL, destination, 
 		return err
 	}
 	defer reader.Close()
-	if err := os.MkdirAll(cache.scratch, 0o700); err != nil {
+	if err := cache.EnsureScratch(); err != nil {
 		return err
 	}
 	temporary, err := os.CreateTemp(cache.scratch, ".waldo-download-*")

--- a/internal/lookaside/cache_test.go
+++ b/internal/lookaside/cache_test.go
@@ -438,3 +438,24 @@ func digestOf(value string) string {
 	digest := sha256.Sum256([]byte(value))
 	return hex.EncodeToString(digest[:])
 }
+
+func TestEnsureScratchTightensAnExistingRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "scratch")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cache, err := NewCache(root, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.EnsureScratch(); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(cache.Scratch())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o700 {
+		t.Fatalf("mode = %04o; a root left wider by an older command must be corrected", mode)
+	}
+}

--- a/internal/modelquant/quant.go
+++ b/internal/modelquant/quant.go
@@ -11,15 +11,26 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
+	"unicode/utf8"
 )
 
 const Profile = "openwaldo-gguf-quant-schema-1"
+
+const (
+	toolProbeTimeout   = 10 * time.Second
+	toolProbeWaitDelay = 2 * time.Second
+	toolVersionMaximum = 4096
+	// llama-quantize answers an unknown flag with usage text and this status.
+	toolUsageExit = 1
+)
 
 var profiles = map[string]string{
 	"2": "Q2_K",
@@ -138,15 +149,77 @@ func resolveTool(ctx context.Context, name string) (Tool, error) {
 	if err != nil {
 		return Tool{}, err
 	}
-	output, err := exec.CommandContext(ctx, absolute, "--version").CombinedOutput()
+	version, err := probeVersion(ctx, absolute, toolProbeTimeout, declinesVersion(name))
 	if err != nil {
-		return Tool{}, fmt.Errorf("%s --version: %w: %s", absolute, err, strings.TrimSpace(string(output)))
-	}
-	version := strings.TrimSpace(string(output))
-	if version == "" {
-		return Tool{}, fmt.Errorf("%s --version returned no identity", absolute)
+		return Tool{}, err
 	}
 	return Tool{Name: name, Version: version, SHA256: digest, path: absolute}, nil
+}
+
+// declinesVersion reports the tools known not to implement --version.
+func declinesVersion(name string) bool { return name == "llama-quantize" }
+
+// probeVersion asks a tool to name itself within budget. The version is best
+// effort; only a tool that failed in a way it should not is an error.
+func probeVersion(ctx context.Context, absolute string, budget time.Duration, declines bool) (string, error) {
+	probeCtx, cancelProbe := context.WithTimeout(ctx, budget)
+	defer cancelProbe()
+	command := exec.CommandContext(probeCtx, absolute, "--version")
+	// A wrapper can leave a grandchild holding the pipe after the child is killed.
+	command.WaitDelay = toolProbeWaitDelay
+	output, probeErr := command.CombinedOutput()
+	var exitErr *exec.ExitError
+	switch {
+	// First: a late cancel reports ErrWaitDelay, which would read as success.
+	case ctx.Err() != nil:
+		return "", fmt.Errorf("%s --version: %w", absolute, ctx.Err())
+	case probeErr == nil:
+		return toolVersion(output), nil
+	case errors.Is(probeErr, exec.ErrWaitDelay):
+		return toolVersion(output), nil
+	// A slow host must not fail an export.
+	case probeCtx.Err() != nil:
+		return "", nil
+	// ExitCode is -1 for a signalled process, so a crash never lands here.
+	case declines && errors.As(probeErr, &exitErr) && exitErr.ExitCode() == toolUsageExit:
+		return "", nil
+	default:
+		return "", fmt.Errorf("%s --version: %w: %s", absolute, probeErr, bound(strings.TrimSpace(string(output))))
+	}
+}
+
+// toolVersion reduces a tool's output to the identity the release BOM keeps.
+// Diagnostics can precede the version, so prefer the line that names one; a
+// lone line is taken at its word and anything else reports nothing.
+func toolVersion(output []byte) string {
+	var seen []string
+	for _, line := range strings.Split(string(output), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(strings.ToLower(line), "version:") {
+			return bound(line)
+		}
+		if line != "" {
+			seen = append(seen, line)
+		}
+	}
+	if len(seen) == 1 {
+		return bound(seen[0])
+	}
+	return ""
+}
+
+// bound keeps the value to what a provenance field can carry: valid UTF-8 that
+// reads back from the BOM as written, and short enough to stay a version.
+func bound(value string) string {
+	value = strings.ToValidUTF8(value, "")
+	if len(value) <= toolVersionMaximum {
+		return value
+	}
+	data := []byte(value)[:toolVersionMaximum]
+	for len(data) > 0 && !utf8.Valid(data) {
+		data = data[:len(data)-1]
+	}
+	return string(data)
 }
 
 func run(ctx context.Context, tool Tool, arguments []string) error {

--- a/internal/modelquant/quant_test.go
+++ b/internal/modelquant/quant_test.go
@@ -7,9 +7,14 @@ package modelquant
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+	"unicode/utf8"
 )
 
 func TestResolveProfile(t *testing.T) {
@@ -61,5 +66,235 @@ func writeExecutable(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o700); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestResolveToolAcceptsUnversionedTool(t *testing.T) {
+	directory := t.TempDir()
+	silent := filepath.Join(directory, "llama-quantize")
+	writeExecutable(t, silent, "#!/bin/sh\necho 'usage: llama-quantize [--help]' >&2\nexit 1\n")
+	speaking := filepath.Join(directory, "llama-imatrix")
+	writeExecutable(t, speaking, "#!/bin/sh\necho 'version: 9843 (4b72bb9d7)'\n")
+	t.Setenv("PATH", directory)
+
+	quantizer, err := resolveTool(context.Background(), "llama-quantize")
+	if err != nil {
+		t.Fatalf("a present, working quantizer was rejected: %v", err)
+	}
+	if quantizer.SHA256 == "" {
+		t.Fatal("the tool must still be pinned by digest when it reports no version")
+	}
+	if quantizer.Version != "" {
+		t.Fatalf("version = %q, want empty for a tool that does not report one", quantizer.Version)
+	}
+
+	calibrator, err := resolveTool(context.Background(), "llama-imatrix")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calibrator.Version != "version: 9843 (4b72bb9d7)" {
+		t.Fatalf("a tool that reports a version must still have it recorded: %q", calibrator.Version)
+	}
+}
+
+func TestResolveToolFailsWhenContextEnds(t *testing.T) {
+	directory := t.TempDir()
+	slow := filepath.Join(directory, "llama-quantize")
+	writeExecutable(t, slow, "#!/bin/sh\n/bin/sleep 2\n")
+	t.Setenv("PATH", directory)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	if _, err := resolveTool(ctx, "llama-quantize"); err == nil {
+		t.Fatal("a tool that outlived the context was accepted")
+	} else if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error should identify the expired context: %v", err)
+	}
+}
+
+func TestResolveToolRejectsUnrunnableBinary(t *testing.T) {
+	directory := t.TempDir()
+	broken := filepath.Join(directory, "llama-quantize")
+	writeExecutable(t, broken, "\x00\x01\x02not an executable image")
+	t.Setenv("PATH", directory)
+
+	// The advice naming llama-quantize is static wrapper text. Assert on the
+	// path, which reaches the message only when the probe reports the failure.
+	if _, err := ResolveRuntime(context.Background(), false); err == nil {
+		t.Fatal("a binary that cannot be executed was accepted at resolution")
+	} else if !strings.Contains(err.Error(), broken) {
+		t.Fatalf("error should name the file the operator must fix: %v", err)
+	}
+}
+
+func TestResolveToolRecordsVersionLineNotDeviceNoise(t *testing.T) {
+	directory := t.TempDir()
+	noisy := filepath.Join(directory, "llama-quantize")
+	// llama.cpp reports its version on standard error, after device diagnostics.
+	writeExecutable(t, noisy, "#!/bin/sh\n{ echo 'ggml_cuda_init: found 1 ROCm devices'; echo '  Device 0: AMD Radeon Graphics'; echo 'version: 8298 (f90bd1dd8)'; echo 'built with GNU 11.5.0'; } >&2\n")
+	t.Setenv("PATH", directory)
+
+	tool, err := resolveTool(context.Background(), "llama-quantize")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tool.Version != "version: 8298 (f90bd1dd8)" {
+		t.Fatalf("version = %q, want the reported version rather than a diagnostic", tool.Version)
+	}
+}
+
+func TestResolveToolKeepsVersionWhenGrandchildHoldsPipe(t *testing.T) {
+	directory := t.TempDir()
+	lingering := filepath.Join(directory, "llama-imatrix")
+	// The tool answers and exits; a background child it spawned keeps the
+	// inherited pipe open, which is what makes CombinedOutput report
+	// exec.ErrWaitDelay instead of success.
+	writeExecutable(t, lingering, "#!/bin/sh\n/bin/sleep 30 &\necho 'version: 8298 (f90bd1dd8)'\n")
+	t.Setenv("PATH", directory)
+
+	tool, err := resolveTool(context.Background(), "llama-imatrix")
+	if err != nil {
+		t.Fatalf("a tool that answered and exited must resolve: %v", err)
+	}
+	if tool.Version != "version: 8298 (f90bd1dd8)" {
+		t.Fatalf("version = %q; the answer was read before the pipe was abandoned", tool.Version)
+	}
+}
+
+func TestProbeVersionFailsWhenCallerCancelsAsPipeLingers(t *testing.T) {
+	directory := t.TempDir()
+	lingering := filepath.Join(directory, "llama-quantize")
+	// The tool exits successfully but a grandchild holds the pipe, so the probe
+	// reports ErrWaitDelay. A caller that gave up inside that window must still
+	// fail rather than have the cancellation read as a successful probe.
+	writeExecutable(t, lingering, "#!/bin/sh\n/bin/sleep 10 &\necho 'version: 8298 (f90bd1dd8)'\n")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+	if _, err := probeVersion(ctx, lingering, 10*time.Second, true); err == nil {
+		t.Fatal("cancellation was swallowed by the lingering pipe")
+	} else if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error should identify the expired context: %v", err)
+	}
+}
+
+func TestProbeVersionAcceptsToolThatOutlivesProbe(t *testing.T) {
+	directory := t.TempDir()
+	slow := filepath.Join(directory, "llama-quantize")
+	writeExecutable(t, slow, "#!/bin/sh\n/bin/sleep 60\n")
+
+	// The budget is a parameter so this pins the behaviour without paying the
+	// production timeout on every run.
+	budget := 200 * time.Millisecond
+	started := time.Now()
+	// declines=false: a slow host is excused even for a tool that should answer.
+	version, err := probeVersion(context.Background(), slow, budget, false)
+	if err != nil {
+		t.Fatalf("a tool too slow to answer must not fail the export: %v", err)
+	}
+	if version != "" {
+		t.Fatalf("version = %q; an unanswered probe records none", version)
+	}
+	if elapsed := time.Since(started); elapsed > budget+toolProbeWaitDelay+2*time.Second {
+		t.Fatalf("the probe took %s; it did not bound its own wait", elapsed)
+	}
+}
+
+func TestResolveToolBoundsReportedVersion(t *testing.T) {
+	directory := t.TempDir()
+	chatty := filepath.Join(directory, "llama-quantize")
+	// PATH is restricted to the temp directory below, so build the long line
+	// with shell builtins rather than a command that will not be found.
+	writeExecutable(t, chatty, "#!/bin/sh\ns=xxxxxxxxxxxxxxxx\nwhile [ ${#s} -lt 200000 ]; do s=\"$s$s\"; done\nprintf '%s' \"$s\"\n")
+	t.Setenv("PATH", directory)
+
+	tool, err := resolveTool(context.Background(), "llama-quantize")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tool.Version) > toolVersionMaximum {
+		t.Fatalf("version is %d bytes; the release BOM must not carry an unbounded value", len(tool.Version))
+	}
+}
+
+func TestToolVersionReportsOneLineOrNothing(t *testing.T) {
+	// A field the release BOM carries as the tool's identity must never hold a
+	// multi-line banner, and must not hold the first line of a diagnostic just
+	// because the tool printed one.
+	for name, expectation := range map[string]struct{ output, want string }{
+		"named":       {"ggml_cuda_init: found 1 ROCm devices\nversion: 9843 (4b72bb9d7)\nbuilt with GNU\n", "version: 9843 (4b72bb9d7)"},
+		"single":      {"llama-imatrix v1.2.3\n", "llama-imatrix v1.2.3"},
+		"padded":      {"\n\n  quantize 0.9  \n\n", "quantize 0.9"},
+		"banner":      {"llama-imatrix v1.2.3\nbuilt with clang 19\ntarget x86_64-linux\n", ""},
+		"diagnostics": {"ggml_vulkan: Found 1 Vulkan devices:\nllama-quantize (llama.cpp) b9843\n", ""},
+		"usage":       {"usage: tool [--help]\n  --version:  print version\n  --foo\n", ""},
+		"blank":       {"   \n\n", ""},
+	} {
+		if got := toolVersion([]byte(expectation.output)); got != expectation.want {
+			t.Errorf("%s: version = %q, want %q", name, got, expectation.want)
+		}
+	}
+}
+
+func TestBoundKeepsValueJSONSafe(t *testing.T) {
+	// The value is written to the release BOM, so it has to read back as it was
+	// written whether or not the tool emitted valid UTF-8.
+	for name, value := range map[string]string{
+		"invalid":   "version: \xff\xfe broken",
+		"oversized": "version: " + strings.Repeat("æ—¥", 3000),
+		"clean":     "version: 9843 (4b72bb9d7)",
+	} {
+		got := bound(value)
+		if !utf8.ValidString(got) {
+			t.Errorf("%s: bound produced invalid UTF-8", name)
+		}
+		encoded, err := json.Marshal(got)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		var decoded string
+		if err := json.Unmarshal(encoded, &decoded); err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if decoded != got {
+			t.Errorf("%s: value did not survive a JSON round trip", name)
+		}
+		if len(got) > toolVersionMaximum {
+			t.Errorf("%s: %d bytes exceeds the bound", name, len(got))
+		}
+	}
+}
+
+func TestProbeVersionRejectsFailuresThatAreNotAUsageRefusal(t *testing.T) {
+	directory := t.TempDir()
+	for name, script := range map[string]string{
+		"crash":       "#!/bin/sh\nkill -SEGV $$\n",
+		"exit127":     "#!/bin/sh\necho 'error while loading shared libraries: libfoo.so' >&2\nexit 127\n",
+		"exit2":       "#!/bin/sh\nexit 2\n",
+		"usageButNot": "#!/bin/sh\nexit 1\n",
+	} {
+		tool := filepath.Join(directory, name)
+		writeExecutable(t, tool, script)
+		// declines=false: a tool expected to answer --version must not have any
+		// of these excused, including the usage status itself.
+		if _, err := probeVersion(context.Background(), tool, 10*time.Second, false); err == nil {
+			t.Errorf("%s: a tool expected to report a version was accepted after failing", name)
+		}
+	}
+}
+
+func TestProbeVersionExcusesOnlyTheUsageRefusal(t *testing.T) {
+	directory := t.TempDir()
+	usage := filepath.Join(directory, "llama-quantize")
+	writeExecutable(t, usage, "#!/bin/sh\necho 'usage: llama-quantize [--help]' >&2\nexit 1\n")
+	if version, err := probeVersion(context.Background(), usage, 10*time.Second, true); err != nil || version != "" {
+		t.Fatalf("the known usage refusal must be excused: %q %v", version, err)
+	}
+
+	crashing := filepath.Join(directory, "crashing")
+	writeExecutable(t, crashing, "#!/bin/sh\nkill -SEGV $$\n")
+	// Even for the tool allowed to decline, a signal is not a refusal.
+	if _, err := probeVersion(context.Background(), crashing, 10*time.Second, true); err == nil {
+		t.Fatal("a crash was excused as a usage refusal")
 	}
 }

--- a/testing/e2e/model-mlx.sh
+++ b/testing/e2e/model-mlx.sh
@@ -237,6 +237,10 @@ assert quant["requested"] == "4"
 assert quant["resolved"] == "Q4_K_M"
 assert quant["quantizer"]["name"] == "llama-quantize"
 assert quant["calibrator"]["name"] == "llama-imatrix"
+# llama-quantize reports no version, so the digest is the only identity the
+# release carries for it. It must never be empty.
+assert len(quant["quantizer"]["sha256"]) == 64
+assert len(quant["calibrator"]["sha256"]) == 64
 calibration = quant["calibration"]
 assert calibration["sampled_tokens"] > 0
 assert calibration["records"] > 0


### PR DESCRIPTION
## What changed

Two defects, either of which stops `waldo model export --quant` from running on
a working installation. The first gates the second: `ResolveRuntime` runs at
`internal/cli/model.go:939` and `calibration.Prepare` at `:962`, so the
calibration failure is unreachable until the probe is fixed. They are kept as
separate commits.

### 1. The quantizer is rejected for not implementing `--version`

`internal/modelquant/quant.go` resolved its tools by running `<tool> --version`
and rejecting anything that exited non-zero. `llama-quantize` parses its own
arguments and has no `--version`; it answers with usage text and status 1. The
other llama.cpp tools use the shared parser and do support it.

Measured against a local build of upstream `6f4f53f2b` carrying unrelated
local patches (they add flags and never touch version handling, so the sample
output below reports that build's own commit): `llama-cli`,
`llama-perplexity` and `llama-imatrix` each exit 0 and report a version, while
`llama-quantize` exits 1. That same binary then quantizes a 19,102,112 byte
model to 6,567,328 bytes and exits 0, so it works, it just cannot name itself.
The error told the operator to install llama.cpp and put `llama-quantize` on
PATH when it was already both.

This is not stale. On current master (`4df29be4f`),
`tools/quantize/quantize.cpp` still parses its own argv with a `strcmp` loop
whose flag list has no `--version`; the `llama_print_build_info` call it does
make runs during a quantize, not as a flag handler.

The probe moves into `probeVersion`, where every outcome is a named case: a
cancelled caller fails; a tool that answers is recorded; a tool that declines
the flag or does not answer within ten seconds is recorded without a version;
only a tool that could not be run at all is an error. The resolver already
computes a SHA-256 and the release BOM already carries it, so a tool that
reports no version stays identified by its digest:

```json
"quantizer": {"name": "llama-quantize", "version": "", "sha256": "0bef37e6..."}
```

`json:"version"` has no `omitempty`, so the key stays present and a consumer can
tell "no version reported" from "field absent".

Bounding the probe fixed a second thing. Resolution set no `WaitDelay`, so
`CombinedOutput` waited on the pipe rather than the process, and any background
child of the probe stalled the export for as long as it lived. With a wrapper
that leaves a 30-second child, resolution took 30.22s before and 2.02s after.

### 2. `--calibration` cannot create its own scratch directory

On a host where the scratch root does not exist yet, one flag apart:

```
--quant 4 --calibration core/common-pile/public-domain-review
  -> Error: stat /tmp/waldo-0/scratch: no such file or directory
--quant 4
  -> exported successfully
```

`os.MkdirTemp` requires its parent to exist, and the scratch root defaults
beneath the system temporary directory, so nothing guarantees it is there.

Two call sites already created that root, at two different modes: the lookaside
cache at 0700 before its download temporaries, and `model train-worker`, which
reached it as a side effect of `MkdirAll` on a deeper path at 0755. The mode of
a shared directory was decided by whichever command a host ran first.
`Cache.EnsureScratch` gives it one owner for both its existence and its mode,
and all three call sites use it.

The per-node and per-stage training directories beneath it tighten from 0755 to
0700 to match. Their consumers are same-user children: the training package
spawns workers with `exec.CommandContext` and `SysProcAttr{Setpgid: true}` and
nothing else, with no `Credential`, no setuid and no container, and both
directories are removed when the run ends.

### Why CI did not catch either

`resolveTool` had no coverage. Existing tests build `Tool` literals with the
unexported `path` field set directly, so they never resolve a real binary. The
only end-to-end test covering a quantized export is gated behind both
`command -v llama-quantize` and a Metal-capable MLX Python runtime
(`testing/e2e/model-mlx.sh:224`), so it skips on Linux CI and on any macOS
runner without MLX. Calibration is gated the same way.

## Verification

Byte counts, re-measured against the final branch:

| quant | bytes |
| --- | --- |
| source | 19,102,112 |
| Q8_0 | 10,161,568 |
| Q6_K | 9,590,176 |
| Q4_K_M | 6,567,328 |

Q4_K_M matches byte for byte what `llama-quantize` produces when driven by hand.

Calibrated export end to end on a Ryzen AI Max+ 395 (gfx1151), from a scratch
root that did not exist:

```
calibration   resolved core/common-pile/public-domain-review: 1 shards, 1.5M reference tokens
calibration   selected 100.0K byte tokens from 21 records in 1 shards
quantization  writing high-precision GGUF / measuring importance / quantizing as Q4_K_M
exported gguf model fix10m

quantizer  version=''                          sha256=0bef37e6...  (64 chars)
calibrator version='version: 9843 (4b72bb9d7)' sha256=6ae9286b...  (64 chars)
```

The quantizer reports nothing and stays pinned by digest. The calibrator is
recorded from the line that names a version, which matters because llama.cpp
answers on standard error and device diagnostics can appear ahead of it; that is
how a diagnostic line came to be recorded as the version during development. The
scratch root is created 0700 and left empty.

Ten tests cover the probe and its two helpers. Six fail against main's probe
semantics, including the reported bug, the diagnostic-line capture, and one that
waits the full 60 seconds on main for a tool that never answers. A seventh
passes on main but takes 30.23s there against 2.22s here, which is the pipe
defect above. `RejectsUnrunnableBinary` is a guard and passes either way. The
last two cover `toolVersion` and `bound`, helpers this PR introduces, and each
fails with its own fix reverted.

CI covers `ubuntu-latest` and `macos-latest`, so its four steps were run on both:
`gofmt`, `go vet ./...`, `go test ./...` across 23 packages, and
`ingest-direct.sh`. All pass, `-race` included. `./testing/all.sh` passes on
both; on Linux that also runs the real PyTorch lifecycle, which skips on macOS.
The four timing-sensitive tests ran 13 iterations and 52 executions, including
with every core saturated, without flaking or drifting.

`model train-worker` has no automated coverage, since
`model-torchtitan-multinode.sh` needs 2+ visible CUDA GPUs plus a TorchTitan
runtime and is opt-in behind `WALDO_E2E_MULTINODE=1`. Its scratch modes were
checked by running it against an unreachable rendezvous and inspecting the tree
while it polled: 0700 at every level including `node-1`, with `node-1` removed
on exit and the shared root left at 0700.

## Contracts

No durable format change and no ADR needed. `docs/COMPATIBILITY.md` requires an
ADR for a change to a persistent format's `kind` or `schema`, and neither moves.
`quantization.quantizer.version` keeps its type and its place in `BOM.json`, and
with no `omitempty` the key is present either way. Only the value changes: it
can now be empty, where before the export failed outright rather than producing
a BOM at all.

ADR 0027 says release evidence "hashes and identifies both executables". Both
still hold, since the SHA-256 and the name are unchanged, and it does not
mention a version field.

`Tool.Version` is documented as best effort in
`docs/TRAINING-AND-CALIBRATION.md`, since an empty version would otherwise read
as "this tool has no `--version`" when the host may just have been slow.
`internal/modelquant` is an internal package, which `docs/COMPATIBILITY.md`
lists as not a compatibility surface.

One behaviour change sits outside this PR's subject and is worth naming: the
per-node and per-stage `model train-worker` scratch directories tighten from
0755 to 0700. Commit 2 explains why.

## DCO

- [x] Every commit includes a `Signed-off-by` trailer (`git commit --signoff`).
