### PR TITLE
Add tools capability to Ollama exports

### DIFF
--- a/internal/modelexport/gguf.go
+++ b/internal/modelexport/gguf.go
@@ -59,6 +59,16 @@ const (
 	ggufArray   = 9
 )
 
+// Add tools capability to Ollama exports.
+// Does not mean the model has actually been trained in tools.
+const ollamaToolTemplate = `TEMPLATE """{{ if .System }}{{ .System }}
+{{ end }}{{ if .Tools }}You have access to the following tools:
+{{ range .Tools }}{{ .Function.Name }}: {{ .Function.Description }}
+{{ end }}
+{{ end }}{{ range .Messages }}{{ .Role }}: {{ .Content }}
+{{ end }}assistant: """
+`
+
 func ExportGGUF(ctx context.Context, inspection model.Inspection, destination string, options Options) (string, error) {
 	return exportGGUFPackage(ctx, inspection, destination, options, false)
 }
@@ -124,7 +134,7 @@ func exportGGUFPackage(ctx context.Context, inspection model.Inspection, destina
 	roles := map[string]string{"model.gguf": "weights", "EU-BOM.json": "regulatory-disclosure"}
 	if ollama {
 		format = "ollama"
-		modelfile := fmt.Sprintf("FROM ./model.gguf\nPARAMETER num_ctx %d\n", inspection.Model.Architecture.ContextTokens)
+		modelfile := fmt.Sprintf("FROM ./model.gguf\nPARAMETER num_ctx %d\n%s", inspection.Model.Architecture.ContextTokens, ollamaToolTemplate)
 		if err := os.WriteFile(filepath.Join(temporary, "Modelfile"), []byte(modelfile), 0o644); err != nil {
 			return "", err
 		}


### PR DESCRIPTION
## What changed

When using ollama exported model with opencode, if the model doesn't advertise tools to ollama capabilities, opencode will close the connection immediately. This simple adds tools to the capabilities of ollama exports. 

## Verification

```(main) mdagosta@orpheus:~/src/openwaldo/waldo> gofmt -l internal/modelexport/gguf.go
(main) mdagosta@orpheus:~/src/openwaldo/waldo> go vet ./...
(main) mdagosta@orpheus:~/src/openwaldo/waldo> go build ./...
(main) mdagosta@orpheus:~/src/openwaldo/waldo> go test ./...
?   	github.com/openwaldo/waldo/cmd/waldo	[no test files]
ok  	github.com/openwaldo/waldo/composes	0.385s
ok  	github.com/openwaldo/waldo/internal/ai	0.576s
ok  	github.com/openwaldo/waldo/internal/calibration	1.017s
?   	github.com/openwaldo/waldo/internal/canon	[no test files]
ok  	github.com/openwaldo/waldo/internal/cli	8.143s
ok  	github.com/openwaldo/waldo/internal/config	1.361s
ok  	github.com/openwaldo/waldo/internal/corpus	0.435s
ok  	github.com/openwaldo/waldo/internal/disclosure	0.575s
ok  	github.com/openwaldo/waldo/internal/git	2.481s
ok  	github.com/openwaldo/waldo/internal/index	1.570s
ok  	github.com/openwaldo/waldo/internal/inference	5.600s
ok  	github.com/openwaldo/waldo/internal/ingest	11.466s
ok  	github.com/openwaldo/waldo/internal/lookaside	2.712s
ok  	github.com/openwaldo/waldo/internal/mlxruntime	2.160s
ok  	github.com/openwaldo/waldo/internal/model	9.030s
ok  	github.com/openwaldo/waldo/internal/modelexport	(cached)
ok  	github.com/openwaldo/waldo/internal/modelquant	8.649s
ok  	github.com/openwaldo/waldo/internal/modelweights	3.046s
ok  	github.com/openwaldo/waldo/internal/provenance	3.231s
ok  	github.com/openwaldo/waldo/internal/record	2.598s
ok  	github.com/openwaldo/waldo/internal/shard	3.778s
ok  	github.com/openwaldo/waldo/internal/signing	3.587s
ok  	github.com/openwaldo/waldo/internal/tokenizer	2.460s
ok  	github.com/openwaldo/waldo/internal/training	10.055s
?   	github.com/openwaldo/waldo/testing/e2e	[no test files]
?   	github.com/openwaldo/waldo/testing/e2e/validate_conversation	[no test files]
```

## Contracts

This does add to prompts for ollama clients, and it does open up the door for the client to try to call on tools.

## DCO

- [ ] Every commit includes a `Signed-off-by` trailer (`git commit --signoff`).
