### PR TITLE
Report local host training readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ With no configured index, read-only index commands use a managed checkout at
 `~/.waldo/index`:
 
 ```bash
+waldo status
 waldo index list
 waldo index summary
 waldo index verify --offline

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,6 +76,8 @@ contract. Export conversion is split across `internal/modelexport`,
 ### Cross-cutting packages
 
 - `internal/config`: machine-local transport and execution preferences.
+- `internal/host`: framework-independent local CPU, memory, and filesystem facts.
+- `internal/status`: read-only index, lookaside, and training readiness orchestration.
 - `internal/canon`: deterministic serialization helpers.
 - `internal/calibration`: forecast and quantization calibration evidence.
 - `internal/disclosure`: EU GPAI disclosure projection.

--- a/docs/MODEL-LIFECYCLE.md
+++ b/docs/MODEL-LIFECYCLE.md
@@ -469,7 +469,9 @@ resolve a deduplicated selection, recommend the largest model rung supported by
 roughly 20 tokens per parameter, and forecast one pass. Forecast creates no
 model or run state. Human forecasts report the derived approximate parameter
 count in both compact and exact form; JSON exposes the same value as
-`approximate_parameters`.
+`approximate_parameters`. WALDO reports missing or empty compose files as input
+errors rather than treating their filenames as corpus paths. Logical corpus
+selections use the normal configured-index refresh before resolution.
 
 By default the forecast resolves the same MLX, PyTorch, or TorchTitan harness
 that training would use, compares the workload with the current host's memory,

--- a/docs/MODEL-LIFECYCLE.md
+++ b/docs/MODEL-LIFECYCLE.md
@@ -461,6 +461,7 @@ the index Git identity when available.
 waldo model forecast model.yaml
 waldo model forecast /path/to/waldo-index/core/books
 waldo model forecast core/books science/papers
+waldo model forecast model.yaml --compare-hosts
 ```
 
 A compose supplies exact architecture and training budgets. Direct index paths
@@ -470,7 +471,14 @@ model or run state. Human forecasts report the derived approximate parameter
 count in both compact and exact form; JSON exposes the same value as
 `approximate_parameters`.
 
-Only configurations that fit are shown, from slowest to fastest:
+By default the forecast resolves the same MLX, PyTorch, or TorchTitan harness
+that training would use, compares the workload with the current host's memory,
+and reports `Ready: yes` or explains why it is not ready. A matching catalog or
+observed-run profile also supplies an approximate duration. Backend discovery
+or local readiness failure does not discard the workload forecast.
+
+`--compare-hosts` additionally shows fitting catalog configurations from
+slowest to fastest:
 
 ```text
 PARAMETERS:  9.5M (9,543,210)
@@ -490,8 +498,10 @@ runs beneath `model.root` and measures their active attempt time. Evidence is
 aggregated only for the exact accelerator model and GPU count observed; that
 row uses measured throughput, while every unmatched row retains its dated
 catalog value and overhead. Human output states when local calibration is
-applied. JSON includes the formula, source per row, unrounded inputs, aggregate
-run count, measured seconds and FLOPs, and a hash of the contributing evidence.
+applied. JSON includes local readiness and omits comparison configurations
+unless `--compare-hosts` is given. The comparison includes the formula, source
+per row, unrounded inputs, aggregate run count, measured seconds and FLOPs, and
+a hash of the contributing evidence.
 
 ## Backend boundary
 

--- a/docs/MODEL-LIFECYCLE.md
+++ b/docs/MODEL-LIFECYCLE.md
@@ -475,7 +475,10 @@ By default the forecast resolves the same MLX, PyTorch, or TorchTitan harness
 that training would use, compares the workload with the current host's memory,
 and reports `Ready: yes` or explains why it is not ready. A matching catalog or
 observed-run profile also supplies an approximate duration. Backend discovery
-or local readiness failure does not discard the workload forecast.
+or local readiness failure does not discard the workload forecast. When the
+workload exceeds local memory, WALDO recommends remote compute with sufficient
+usable memory. A workload larger than every dated catalog configuration still
+returns its conservative resource forecast instead of failing.
 
 `--compare-hosts` additionally shows fitting catalog configurations from
 slowest to fastest:

--- a/docs/UX.md
+++ b/docs/UX.md
@@ -8,6 +8,7 @@ for flags and detailed behavior.
 ```text
 waldo
 ├── advisor
+├── status
 ├── config
 │   ├── show
 │   ├── get
@@ -57,6 +58,18 @@ waldo
 
 There is no top-level `waldo bom` command. Corpus BOM operations are under
 `waldo index bom`; model BOM operations are under `waldo model bom`.
+
+## Local readiness
+
+```bash
+waldo status
+```
+
+`status` inspects local resources, the selected index, lookaside paths, and the
+training harness chosen by the same environment resolver used by `model
+train`. It performs no network requests and changes no state. Each unavailable
+workflow reports `Ready: no` and explains why. Global `--json` returns the
+same structured facts for automation.
 
 ## Index selection
 
@@ -174,7 +187,9 @@ waldo model chat canary
 waldo model export --help
 ```
 
-Run `forecast` before allocating substantial compute. Training and generation
+`forecast` reports readiness and runtime for the current host. Add
+`--compare-hosts` to include the versioned hardware comparison. Run `forecast`
+before allocating substantial compute. Training and generation
 fail when the selected host lacks a compatible runtime or artifacts.
 Models with a declared `interaction.template` automatically receive the
 matching prompt format and multi-turn history in `model chat`; models without

--- a/docs/adr/0063-current-host-forecast.md
+++ b/docs/adr/0063-current-host-forecast.md
@@ -1,0 +1,32 @@
+# 0063: Forecast the current host by default
+
+## Status
+
+Accepted
+
+## Decision
+
+`waldo model forecast` reports whether its resolved workload is ready to train
+on the current host. It selects MLX, PyTorch, or TorchTitan through the same
+environment resolver used by training, compares the resulting execution
+topology with the existing memory forecast, and uses exact observed-run or
+catalog evidence only when the accelerator topology matches.
+
+The versioned hardware catalog remains available through the explicit
+`--compare-hosts` option. A missing local backend or unknown local performance
+does not prevent WALDO from producing the portable workload forecast.
+
+`waldo status` owns workload-independent readiness. It reports host resources,
+index and lookaside configuration, and whether the production backend resolver
+can select a real training harness. A negative readiness result always carries
+a reason.
+
+## Consequences
+
+- Forecast output answers the common local question without presenting an
+  unrelated hardware grid by default.
+- Backend selection cannot drift between status, forecast, and training.
+- CPU training may be ready without a duration when no trustworthy throughput
+  evidence exists.
+- Host comparison remains explicit and reproducible against the versioned
+  catalog.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -66,3 +66,4 @@ logs.
 - [0060: Preserve conversations and render them in training views](0060-structured-conversation-training-views.md)
 - [0061: Stream record arrays in the JSON container](0061-stream-json-record-arrays.md)
 - [0062: Purge verified cache objects after successful use](0062-purge-successful-lookaside-cache.md)
+- [0063: Forecast the current host by default](0063-current-host-forecast.md)

--- a/internal/cli/advisor.go
+++ b/internal/cli/advisor.go
@@ -622,34 +622,63 @@ type advisorCheckpointMonitor struct {
 	transcript *advisorTranscript
 	output     io.Writer
 	warnings   io.Writer
-	events     chan model.Progress
+	events     chan advisorCheckpointSnapshot
 	done       chan struct{}
+}
+
+// advisorCheckpointSnapshot captures the durable model evidence while the
+// training progress callback still excludes later model-state writes. The AI
+// request remains asynchronous, but it never has to reread a changing set of
+// model files.
+type advisorCheckpointSnapshot struct {
+	event          model.Progress
+	report         model.Advice
+	buildHistory   []advisorBuildSummary
+	composeHistory []string
+	chatHistory    []advisorTurn
 }
 
 func newAdvisorCheckpointMonitor(ctx context.Context, root, name string, selection waldoai.Selection, index advisorIndexEvidence, transcript *advisorTranscript, output, warnings io.Writer) *advisorCheckpointMonitor {
 	monitor := &advisorCheckpointMonitor{
 		ctx: ctx, root: root, name: name, selection: selection, index: index,
 		transcript: transcript, output: output, warnings: warnings,
-		events: make(chan model.Progress, 1), done: make(chan struct{}),
+		events: make(chan advisorCheckpointSnapshot, 1), done: make(chan struct{}),
 	}
 	go monitor.run()
 	return monitor
 }
 
 func (monitor *advisorCheckpointMonitor) Observe(event model.Progress) {
-	_ = monitor.transcript.Flush()
 	if event.Training == nil || event.Training.Kind != "checkpoint" {
 		return
 	}
+	if err := monitor.transcript.Flush(); err != nil {
+		fmt.Fprintf(monitor.warnings, "warning: flush advisor transcript before checkpoint monitor: %v\n", err)
+		return
+	}
+	report, err := currentAdvisorEvidence(monitor.root, monitor.name)
+	if err != nil {
+		fmt.Fprintf(monitor.warnings, "warning: advisor checkpoint monitor: %v\n", err)
+		return
+	}
+	buildHistory, composeHistory, err := currentAdvisorBuildHistory(monitor.root, monitor.name)
+	if err != nil {
+		fmt.Fprintf(monitor.warnings, "warning: advisor checkpoint monitor: %v\n", err)
+		return
+	}
+	snapshot := advisorCheckpointSnapshot{
+		event: event, report: report, buildHistory: buildHistory,
+		composeHistory: composeHistory, chatHistory: monitor.transcript.History(),
+	}
 	select {
-	case monitor.events <- event:
+	case monitor.events <- snapshot:
 	default:
 		select {
 		case <-monitor.events:
 		default:
 		}
 		select {
-		case monitor.events <- event:
+		case monitor.events <- snapshot:
 		default:
 		}
 	}
@@ -662,41 +691,35 @@ func (monitor *advisorCheckpointMonitor) Close() {
 
 func (monitor *advisorCheckpointMonitor) run() {
 	defer close(monitor.done)
-	for event := range monitor.events {
-		report, err := currentAdvisorEvidence(monitor.root, monitor.name)
-		if err != nil {
+	for snapshot := range monitor.events {
+		monitor.process(snapshot)
+	}
+}
+
+func (monitor *advisorCheckpointMonitor) process(snapshot advisorCheckpointSnapshot) {
+	prompt := advisorMonitorPrompt(snapshot.report, snapshot.event, monitor.index, snapshot.buildHistory, snapshot.composeHistory, snapshot.chatHistory)
+	response, err := modelAdvisorAsk(monitor.ctx, monitor.selection, prompt)
+	if err != nil {
+		if monitor.ctx.Err() == nil {
 			fmt.Fprintf(monitor.warnings, "warning: advisor checkpoint monitor: %v\n", err)
-			continue
 		}
-		buildHistory, composeHistory, err := currentAdvisorBuildHistory(monitor.root, monitor.name)
-		if err != nil {
-			fmt.Fprintf(monitor.warnings, "warning: advisor checkpoint monitor: %v\n", err)
-			continue
-		}
-		prompt := advisorMonitorPrompt(report, event, monitor.index, buildHistory, composeHistory, monitor.transcript.History())
-		response, err := modelAdvisorAsk(monitor.ctx, monitor.selection, prompt)
-		if err != nil {
-			if monitor.ctx.Err() == nil {
-				fmt.Fprintf(monitor.warnings, "warning: advisor checkpoint monitor: %v\n", err)
-			}
-			continue
-		}
-		allowed := advisorAllowedCorpora(report.Compose, monitor.index.Corpora)
-		answer, err := parseAdvisorReply(response, report.Compose, allowed, false)
-		if err != nil {
-			fmt.Fprintf(monitor.warnings, "warning: advisor checkpoint monitor returned invalid advice: %v\n", err)
-			continue
-		}
-		if answer.Compose != nil || answer.Build || len(answer.Changes) != 0 {
-			fmt.Fprintln(monitor.warnings, "warning: advisor checkpoint monitor attempted an interactive action; ignoring it")
-			continue
-		}
-		if err := monitor.transcript.Record("assistant", "checkpoint-monitor", answer.Reply); err != nil {
-			fmt.Fprintf(monitor.warnings, "warning: persist advisor checkpoint monitor: %v\n", err)
-		}
-		if err := renderAdvisorMarkdown(monitor.output, fmt.Sprintf("Advisor monitor · step %d", event.Training.Step), answer.Reply); err != nil {
-			fmt.Fprintf(monitor.warnings, "warning: render advisor checkpoint monitor: %v\n", err)
-		}
+		return
+	}
+	allowed := advisorAllowedCorpora(snapshot.report.Compose, monitor.index.Corpora)
+	answer, err := parseAdvisorReply(response, snapshot.report.Compose, allowed, false)
+	if err != nil {
+		fmt.Fprintf(monitor.warnings, "warning: advisor checkpoint monitor returned invalid advice: %v\n", err)
+		return
+	}
+	if answer.Compose != nil || answer.Build || len(answer.Changes) != 0 {
+		fmt.Fprintln(monitor.warnings, "warning: advisor checkpoint monitor attempted an interactive action; ignoring it")
+		return
+	}
+	if err := monitor.transcript.Record("assistant", "checkpoint-monitor", answer.Reply); err != nil {
+		fmt.Fprintf(monitor.warnings, "warning: persist advisor checkpoint monitor: %v\n", err)
+	}
+	if err := renderAdvisorMarkdown(monitor.output, fmt.Sprintf("Advisor monitor · step %d", snapshot.event.Training.Step), answer.Reply); err != nil {
+		fmt.Fprintf(monitor.warnings, "warning: render advisor checkpoint monitor: %v\n", err)
 	}
 }
 

--- a/internal/cli/advisor_test.go
+++ b/internal/cli/advisor_test.go
@@ -8,16 +8,56 @@ package cli
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	waldoai "github.com/openwaldo/waldo/internal/ai"
 	waldoindex "github.com/openwaldo/waldo/internal/index"
 	"github.com/openwaldo/waldo/internal/model"
 	"github.com/openwaldo/waldo/internal/training"
 )
+
+func TestAdvisorCheckpointMonitorProcessesCapturedSnapshotWithoutRereadingModel(t *testing.T) {
+	root, name := t.TempDir(), "changing"
+	modelPath := filepath.Join(root, name)
+	if err := os.MkdirAll(modelPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A transcript only requires MODEL.json to exist before it flushes. Keep it
+	// deliberately invalid: processing a captured snapshot must not inspect it.
+	if err := os.WriteFile(filepath.Join(modelPath, "MODEL.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	transcript := &advisorTranscript{root: root, name: name, session: "test"}
+	var output, warnings bytes.Buffer
+	monitor := &advisorCheckpointMonitor{
+		ctx: context.Background(), root: root, name: name, transcript: transcript,
+		output: &output, warnings: &warnings,
+	}
+	previousAsk := modelAdvisorAsk
+	modelAdvisorAsk = func(_ context.Context, _ waldoai.Selection, prompt string) (string, error) {
+		if !strings.Contains(prompt, `"step": 2`) {
+			t.Fatalf("checkpoint prompt does not contain captured step: %s", prompt)
+		}
+		return `{"reply":"The captured checkpoint is healthy."}`, nil
+	}
+	t.Cleanup(func() { modelAdvisorAsk = previousAsk })
+	monitor.process(advisorCheckpointSnapshot{
+		event:  model.Progress{Training: &training.Event{Kind: "checkpoint", Step: 2}},
+		report: model.Advice{},
+	})
+	chat, err := os.ReadFile(filepath.Join(modelPath, "advisor", "CHAT.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(chat, []byte(`"category":"checkpoint-monitor"`)) || warnings.Len() != 0 {
+		t.Fatalf("checkpoint chat = %s, warnings = %q", chat, warnings.String())
+	}
+}
 
 func TestAdvisorReplySupportsConversationAndValidatesComposeBoundary(t *testing.T) {
 	original := advisorTestCompose()

--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -91,6 +91,7 @@ func newRootCommand() *cobra.Command {
 	root.PersistentFlags().BoolVar(&state.json, "json", false, "emit structured JSON output; progress remains on stderr")
 	root.AddCommand(
 		leaf(state, "advisor <model-name>", "Chat with an AI model advisor", "For an existing model, explains its configuration and live training state and can propose a follow-up compose. For a new name, gathers requirements, creates a validated compose, and starts training only after confirmation.", cobra.ExactArgs(1), runModelAdvisor, advisorFlags()...),
+		leaf(state, "status", "Inspect host and WALDO readiness", "Reports local resources, index configuration, lookaside configuration, and the training harness selected by the same resolver used for model training. It performs no network requests and changes no state.", cobra.NoArgs, runStatus),
 		newIndexCommand(state),
 		newShardCommand(state),
 		newLookasideCommand(state),
@@ -188,7 +189,8 @@ func newModelCommand(state *cobraState) *cobra.Command {
 			textFlag("provider", "", "EU GPAI provider profile override"),
 			booleanFlag("allow-incomplete", "emit a marked incomplete EU GPAI draft"),
 			booleanFlag("force", "replace an existing output file")),
-		leaf(state, "forecast [index-path...] | <compose.yaml>", "Estimate viable GPU configurations and runtime", "Forecasts one pass over selected index tokens or a declared model compose.", cobra.ArbitraryArgs, runModelForecast),
+		leaf(state, "forecast [index-path...] | <compose.yaml>", "Estimate training readiness and runtime", "Forecasts one pass over selected index tokens or a declared model compose on the current host. Use --compare-hosts to include the versioned hardware catalog.", cobra.ArbitraryArgs, runModelForecast,
+			booleanFlag("compare-hosts", "include the versioned training-hardware comparison")),
 		leaf(state, "train <name> [index-path...] | <name> <compose-file>", "Train a model from indexed corpora or a compose", "A compose creates an absent model or trains an existing model with the same architecture. With no input, WALDO trains an existing model on the entire resolved index. --nodes greater than 1 runs a multi-node TorchTitan job (requires the TorchTitan backend; one-pass index training is byte-tokenizer only, while compose-driven training supports every tokenizer); this invocation is the primary (rank 0), and every other node runs `model train-worker` pointed at the primary's --rendezvous host:port with the same --rendezvous-id. The nodes are coupled by --rendezvous; --rendezvous-id names the shared plan-handoff path under model.root that the secondaries consume, so it must match exactly on every node.", modelTrainArgs, runModelTrain,
 			integer64Flag("epochs", 1, "complete training passes (1..1000000)"),
 			integer64Flag("batch-size", 8, "sequences per optimizer step; the global batch across all nodes (1..1000000)"),

--- a/internal/cli/model.go
+++ b/internal/cli/model.go
@@ -182,6 +182,10 @@ func writeModelForecast(stdout io.Writer, report model.ResourceForecast, hostFor
 }
 
 func writeHostComparison(stdout io.Writer, report model.ResourceForecast) {
+	if len(report.Configurations) == 0 {
+		fmt.Fprintf(stdout, "NOTE:        %s\n", singleLine(report.CatalogNote))
+		return
+	}
 	type row struct {
 		manufacturer string
 		accelerator  string
@@ -252,6 +256,9 @@ func writeHostModelForecast(stdout io.Writer, forecast model.HostForecast) {
 	fmt.Fprintf(stdout, "READY:       %s\n", readiness(forecast.Ready))
 	if !forecast.Ready {
 		fmt.Fprintf(stdout, "REASON:      %s\n", singleLine(forecast.Reason))
+		if forecast.Recommendation != "" {
+			fmt.Fprintf(stdout, "RECOMMEND:   %s\n", singleLine(forecast.Recommendation))
+		}
 		return
 	}
 	if forecast.ApproximateSeconds != nil {

--- a/internal/cli/model.go
+++ b/internal/cli/model.go
@@ -48,11 +48,35 @@ func runModelForecast(context Context, args []string, stdout, stderr io.Writer) 
 		if err != nil {
 			return err
 		}
+		if !isCompose {
+			isCompose, err = composeLookingForecastInput(args[0])
+			if err != nil {
+				return err
+			}
+		}
 		if isCompose {
 			return runModelComposeForecast(context, args[0], stdout, stderr)
 		}
 	}
 	return runModelIndexForecast(context, args, stdout, stderr)
+}
+
+func composeLookingForecastInput(path string) (bool, error) {
+	extension := strings.ToLower(filepath.Ext(path))
+	if extension != ".yaml" && extension != ".yml" && extension != ".json" {
+		return false, nil
+	}
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		// A single metadata filename is the documented compose form. Existing
+		// index manifests are still identified by their content and resolved
+		// through the normal index path.
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return !info.IsDir() && info.Size() == 0, nil
 }
 
 func runModelComposeForecast(context Context, path string, stdout, progress io.Writer) error {

--- a/internal/cli/model.go
+++ b/internal/cli/model.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openwaldo/waldo/internal/config"
 	"github.com/openwaldo/waldo/internal/corpus"
 	"github.com/openwaldo/waldo/internal/disclosure"
+	"github.com/openwaldo/waldo/internal/host"
 	waldoindex "github.com/openwaldo/waldo/internal/index"
 	"github.com/openwaldo/waldo/internal/inference"
 	"github.com/openwaldo/waldo/internal/lookaside"
@@ -75,14 +76,25 @@ func runModelComposeForecast(context Context, path string, stdout, progress io.W
 	if err != nil {
 		return err
 	}
+	forecastBuilder, err := configuredForecastBuilder(context)
+	if err != nil {
+		return err
+	}
+	hostForecast, err := forecastComposeHost(context, forecastBuilder, compose, report)
+	if err != nil {
+		return err
+	}
+	compareHosts := boolOption(context, "compare-hosts")
 	if context.JSON {
+		visible := visibleModelForecast(report, compareHosts)
 		return writeJSON(stdout, struct {
 			Compose  string                 `json:"compose"`
 			Forecast model.ResourceForecast `json:"forecast"`
-		}{Compose: composePath, Forecast: report})
+			Host     model.HostForecast     `json:"host"`
+		}{Compose: composePath, Forecast: visible, Host: hostForecast})
 	}
 	fmt.Fprintf(stdout, "COMPOSE:     %s\n", composePath)
-	writeModelForecast(stdout, report)
+	writeModelForecast(stdout, report, hostForecast, compareHosts)
 	return nil
 }
 
@@ -118,7 +130,17 @@ func runModelIndexForecast(context Context, paths []string, stdout, warnings io.
 	if _, err := cache.PurgeUsed(); err != nil {
 		return fmt.Errorf("purge successful forecast cache: %w", err)
 	}
+	builder, err := configuredForecastBuilder(context)
+	if err != nil {
+		return err
+	}
+	hostForecast, err := forecastIndexHost(context, builder, bom.Totals.Tokens, report)
+	if err != nil {
+		return err
+	}
+	compareHosts := boolOption(context, "compare-hosts")
 	if context.JSON {
+		visible := visibleModelForecast(report, compareHosts)
 		return writeJSON(stdout, struct {
 			Index      any                    `json:"index"`
 			Paths      []string               `json:"paths"`
@@ -127,15 +149,16 @@ func runModelIndexForecast(context Context, paths []string, stdout, warnings io.
 			Tokens     int64                  `json:"tokens"`
 			Budget     string                 `json:"budget"`
 			Forecast   model.ResourceForecast `json:"forecast"`
-		}{Index: bom.Index, Paths: bom.Paths, Preset: preset.Name, Parameters: parameters.ApproximateParameters, Tokens: bom.Totals.Tokens, Budget: "one-pass", Forecast: report})
+			Host       model.HostForecast     `json:"host"`
+		}{Index: bom.Index, Paths: bom.Paths, Preset: preset.Name, Parameters: parameters.ApproximateParameters, Tokens: bom.Totals.Tokens, Budget: "one-pass", Forecast: visible, Host: hostForecast})
 	}
 	fmt.Fprintf(stdout, "MODEL:       %s\n", preset.Name)
 	fmt.Fprintln(stdout, "BUDGET:      one pass")
-	writeModelForecast(stdout, report)
+	writeModelForecast(stdout, report, hostForecast, compareHosts)
 	return nil
 }
 
-func writeModelForecast(stdout io.Writer, report model.ResourceForecast) {
+func writeModelForecast(stdout io.Writer, report model.ResourceForecast, hostForecast model.HostForecast, compareHosts bool) {
 	fmt.Fprintf(stdout, "PARAMETERS:  %s\n", humanModelParameters(report.ApproximateParameters))
 	if len(report.EpochDerivedStages) == 0 {
 		fmt.Fprintf(stdout, "TOKENS:      %s\n", humanCount(report.PlannedTokens))
@@ -148,7 +171,17 @@ func writeModelForecast(stdout io.Writer, report model.ResourceForecast) {
 		fmt.Fprintf(stdout, "EPOCHS:      %s resolve during training preflight\n", strings.Join(report.EpochDerivedStages, ", "))
 	}
 	fmt.Fprintln(stdout)
+	writeHostModelForecast(stdout, hostForecast)
+	if !compareHosts {
+		return
+	}
+	fmt.Fprintln(stdout)
+	fmt.Fprintln(stdout, "HOST COMPARISON")
+	fmt.Fprintln(stdout)
+	writeHostComparison(stdout, report)
+}
 
+func writeHostComparison(stdout io.Writer, report model.ResourceForecast) {
 	type row struct {
 		manufacturer string
 		accelerator  string
@@ -192,6 +225,86 @@ func writeModelForecast(stdout io.Writer, report model.ResourceForecast) {
 	fmt.Fprintf(stdout, "%*s  %*s  %-*s  %-*s  %*s  %*s\n", GPUsWidth, "GPUS", nodesWidth, "NODES", manufacturerWidth, "MFR", acceleratorWidth, "ACCELERATOR", memoryWidth, "MEMORY/GPU", durationWidth, "APPROX. TIME")
 	for _, candidate := range rows {
 		fmt.Fprintf(stdout, "%*s  %*s  %-*s  %-*s  %*s  %*s\n", GPUsWidth, candidate.GPUs, nodesWidth, candidate.nodes, manufacturerWidth, candidate.manufacturer, acceleratorWidth, candidate.accelerator, memoryWidth, candidate.memory, durationWidth, candidate.duration)
+	}
+}
+
+func writeHostModelForecast(stdout io.Writer, forecast model.HostForecast) {
+	execution := forecast.Execution
+	fmt.Fprintf(stdout, "HOST:        %s/%s\n", execution.Host.OS, execution.Host.Architecture)
+	if execution.Backend.Name == "" {
+		fmt.Fprintln(stdout, "BACKEND:     unavailable")
+	} else {
+		fmt.Fprintf(stdout, "BACKEND:     %s@%s\n", execution.Backend.Name, execution.Backend.Revision)
+		fmt.Fprintf(stdout, "RUNTIME:     %s\n", singleLine(execution.Runtime))
+	}
+	if len(execution.Accelerators) == 0 {
+		fmt.Fprintln(stdout, "ACCELERATOR: CPU")
+	} else if len(execution.Accelerators) == 1 {
+		accelerator := execution.Accelerators[0]
+		fmt.Fprintf(stdout, "ACCELERATOR: %s\n", acceleratorDisplay(accelerator))
+	} else {
+		accelerator := execution.Accelerators[0]
+		fmt.Fprintf(stdout, "ACCELERATOR: %d x %s\n", len(execution.Accelerators), acceleratorDisplay(accelerator))
+	}
+	if forecast.RequiredMemory > 0 && forecast.AvailableMemory > 0 {
+		fmt.Fprintf(stdout, "MEMORY:      %s required / %s available\n", humanBytesUint(forecast.RequiredMemory), humanBytesUint(forecast.AvailableMemory))
+	}
+	fmt.Fprintf(stdout, "READY:       %s\n", readiness(forecast.Ready))
+	if !forecast.Ready {
+		fmt.Fprintf(stdout, "REASON:      %s\n", singleLine(forecast.Reason))
+		return
+	}
+	if forecast.ApproximateSeconds != nil {
+		fmt.Fprintf(stdout, "TIME:        %s\n", approximateDuration(*forecast.ApproximateSeconds))
+		fmt.Fprintf(stdout, "ESTIMATE:    %s\n", forecast.EstimateSource)
+	}
+}
+
+func visibleModelForecast(report model.ResourceForecast, compareHosts bool) model.ResourceForecast {
+	if !compareHosts {
+		report.Configurations = nil
+	}
+	return report
+}
+
+func configuredForecastBuilder(context Context) (model.Builder, error) {
+	quiet := context
+	quiet.JSON = false
+	return configuredModelBuilder(quiet, io.Discard)
+}
+
+func forecastComposeHost(context Context, builder model.Builder, compose model.Compose, report model.ResourceForecast) (model.HostForecast, error) {
+	facts, err := host.Inspect()
+	if err != nil {
+		return unavailableHostForecast(err), nil
+	}
+	selection, err := builder.ResolveComposeBackend(context.Execution, compose)
+	if err != nil {
+		return unavailableHostForecastFor(facts.OS, facts.Architecture, err), nil
+	}
+	return model.AssessComposeHost(compose, report, selection.Execution, facts.MemoryBytes)
+}
+
+func forecastIndexHost(context Context, builder model.Builder, tokens int64, report model.ResourceForecast) (model.HostForecast, error) {
+	facts, err := host.Inspect()
+	if err != nil {
+		return unavailableHostForecast(err), nil
+	}
+	selection, err := builder.ResolveIndexBackend(context.Execution, tokens)
+	if err != nil {
+		return unavailableHostForecastFor(facts.OS, facts.Architecture, err), nil
+	}
+	return model.AssessIndexHost(tokens, report, selection.Execution, facts.MemoryBytes)
+}
+
+func unavailableHostForecast(err error) model.HostForecast {
+	return model.HostForecast{Reason: err.Error()}
+}
+
+func unavailableHostForecastFor(hostOS, architecture string, err error) model.HostForecast {
+	return model.HostForecast{
+		Reason:    err.Error(),
+		Execution: training.Execution{Host: training.Host{OS: hostOS, Architecture: architecture}},
 	}
 }
 

--- a/internal/cli/model_forecast_test.go
+++ b/internal/cli/model_forecast_test.go
@@ -8,6 +8,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -100,6 +101,35 @@ func TestModelForecastAcceptsConfiguredMultipleIndexPaths(t *testing.T) {
 	code = Run([]string{"model", "forecast", filepath.Join(root, "books"), "--compare-hosts"}, &stdout, &stderr)
 	if code != 0 || !strings.Contains(stdout.String(), "HOST COMPARISON") || !strings.Contains(stdout.String(), "MFR") {
 		t.Fatalf("comparison forecast code = %d, stderr = %q:\n%s", code, stderr.String(), stdout.String())
+	}
+}
+
+func TestModelForecastDistinguishesComposeInputErrorsFromIndexSelections(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing.yaml")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"model", "forecast", missing}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "model compose") || !strings.Contains(stderr.String(), "does not exist") || strings.Contains(stderr.String(), "index path") {
+		t.Fatalf("missing compose code = %d, stdout = %q, stderr = %q", code, stdout.String(), stderr.String())
+	}
+
+	empty := filepath.Join(t.TempDir(), "empty.yaml")
+	if err := os.WriteFile(empty, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"model", "forecast", empty}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "model compose") || !strings.Contains(stderr.String(), "is empty") || strings.Contains(stderr.String(), "index path") {
+		t.Fatalf("empty compose code = %d, stdout = %q, stderr = %q", code, stdout.String(), stderr.String())
+	}
+
+	root := fixtureCLIIndex(t)
+	t.Setenv("WALDO_CONFIG", filepath.Join(t.TempDir(), "config.json"))
+	if err := config.Save(config.Config{Index: root, Model: config.Model{Backend: "fake"}}); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"model", "forecast", "missing/corpus"}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "index path missing/corpus") || strings.Contains(stderr.String(), "model compose") {
+		t.Fatalf("missing index code = %d, stdout = %q, stderr = %q", code, stdout.String(), stderr.String())
 	}
 }
 

--- a/internal/cli/model_forecast_test.go
+++ b/internal/cli/model_forecast_test.go
@@ -142,3 +142,23 @@ func TestWriteModelForecastIdentifiesEpochDerivedWork(t *testing.T) {
 		}
 	}
 }
+
+func TestWriteModelForecastRecommendsRemoteComputeWithoutCatalogFit(t *testing.T) {
+	report := model.ResourceForecast{
+		ApproximateParameters: 1_000_000_000_000,
+		PlannedTokens:         1,
+		CatalogNote:           "no configuration in the forecast catalog has sufficient memory for this workload",
+	}
+	host := model.HostForecast{
+		Reason:         "training requires 1.0 TiB per device, but this host has 128.0 GiB",
+		Recommendation: "use remote compute with at least 1.0 TiB of usable memory per device",
+		Execution:      training.Execution{Host: training.Host{OS: "linux", Architecture: "amd64"}},
+	}
+	var output bytes.Buffer
+	writeModelForecast(&output, report, host, true)
+	for _, want := range []string{"READY:       no", "REASON:", "RECOMMEND:   use remote compute", "HOST COMPARISON", "NOTE:        no configuration"} {
+		if !strings.Contains(output.String(), want) {
+			t.Errorf("forecast output missing %q:\n%s", want, output.String())
+		}
+	}
+}

--- a/internal/cli/model_forecast_test.go
+++ b/internal/cli/model_forecast_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openwaldo/waldo/internal/config"
 	"github.com/openwaldo/waldo/internal/model"
+	"github.com/openwaldo/waldo/internal/training"
 )
 
 func TestApproximateDurationUsesHoursUntilOneHundred(t *testing.T) {
@@ -40,6 +41,7 @@ func TestModelForecastAcceptsConfiguredMultipleIndexPaths(t *testing.T) {
 	t.Chdir(t.TempDir())
 	if err := config.Save(config.Config{
 		Index: root,
+		Model: config.Model{Backend: "fake"},
 		Lookaside: config.Lookaside{
 			Cache: filepath.Join(t.TempDir(), "cache"), Scratch: filepath.Join(t.TempDir(), "scratch"),
 		},
@@ -47,7 +49,7 @@ func TestModelForecastAcceptsConfiguredMultipleIndexPaths(t *testing.T) {
 		t.Fatal(err)
 	}
 	var stdout, stderr bytes.Buffer
-	code := Run([]string{"--json", "model", "forecast", "books", "books/books.json"}, &stdout, &stderr)
+	code := Run([]string{"--json", "model", "forecast", "books", "books/books.json", "--compare-hosts"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, stderr = %q", code, stderr.String())
 	}
@@ -75,6 +77,9 @@ func TestModelForecastAcceptsConfiguredMultipleIndexPaths(t *testing.T) {
 	if stderr.Len() != 0 {
 		t.Fatalf("whole-index forecast stderr = %q", stderr.String())
 	}
+	if strings.Contains(stdout.String(), `"configurations"`) || !strings.Contains(stdout.String(), `"host"`) {
+		t.Fatalf("default JSON forecast exposes comparison or omits host: %s", stdout.String())
+	}
 
 	stdout.Reset()
 	stderr.Reset()
@@ -82,10 +87,19 @@ func TestModelForecastAcceptsConfiguredMultipleIndexPaths(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("directory forecast code = %d, stderr = %q", code, stderr.String())
 	}
-	for _, want := range []string{"MODEL:", "10m", "PARAMETERS:", "TOKENS:", "BUDGET:", "one pass", "MFR", "ACCELERATOR"} {
+	for _, want := range []string{"MODEL:", "10m", "PARAMETERS:", "TOKENS:", "BUDGET:", "one pass", "HOST:", "ACCELERATOR:", "READY:", "no", "REASON:"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Errorf("forecast missing %q:\n%s", want, stdout.String())
 		}
+	}
+	if strings.Contains(stdout.String(), "HOST COMPARISON") || strings.Contains(stdout.String(), "MFR") {
+		t.Fatalf("default forecast includes host comparison:\n%s", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"model", "forecast", filepath.Join(root, "books"), "--compare-hosts"}, &stdout, &stderr)
+	if code != 0 || !strings.Contains(stdout.String(), "HOST COMPARISON") || !strings.Contains(stdout.String(), "MFR") {
+		t.Fatalf("comparison forecast code = %d, stderr = %q:\n%s", code, stderr.String(), stdout.String())
 	}
 }
 
@@ -95,24 +109,23 @@ func TestWriteModelForecastUsesApprovedCompactColumns(t *testing.T) {
 		{Manufacturer: "NVIDIA", Accelerator: "H100 SXM", GPUs: 8, Nodes: 1, MemoryPerGPUBytes: 80 << 30, ApproximateSeconds: 44 * 60 * 60},
 	}}
 	var output bytes.Buffer
-	writeModelForecast(&output, report)
+	writeHostComparison(&output, report)
 	lines := strings.Split(strings.TrimSpace(output.String()), "\n")
-	if len(lines) != 6 {
+	if len(lines) != 3 {
 		t.Fatalf("output = %q", output.String())
 	}
 	for lineNumber, want := range []string{"GPUS", "1", "8"} {
-		lineNumber += 3
 		fields := strings.Fields(lines[lineNumber])
 		if len(fields) == 0 || fields[0] != want {
 			t.Errorf("line %d does not lead with %q:\n%s", lineNumber+1, want, lines[lineNumber])
 		}
 	}
-	for _, want := range []string{"PARAMETERS:  9.5M (9,543,210)", "TOKENS:      1.0B", "MFR", "ACCELERATOR", "GPUS", "NODES", "MEMORY/GPU", "APPROX. TIME", "Apple", "128 GB", "48 days", "NVIDIA", "80 GB", "44 hours"} {
+	for _, want := range []string{"MFR", "ACCELERATOR", "GPUS", "NODES", "MEMORY/GPU", "APPROX. TIME", "Apple", "128 GB", "48 days", "NVIDIA", "80 GB", "44 hours"} {
 		if !strings.Contains(output.String(), want) {
 			t.Errorf("output missing %q:\n%s", want, output.String())
 		}
 	}
-	for _, unwanted := range []string{"BACKEND", "FIT", "~", "unified"} {
+	for _, unwanted := range []string{"BACKEND", "READY", "FIT", "~", "unified"} {
 		if strings.Contains(output.String(), unwanted) {
 			t.Errorf("output unexpectedly contains %q:\n%s", unwanted, output.String())
 		}
@@ -122,7 +135,7 @@ func TestWriteModelForecastUsesApprovedCompactColumns(t *testing.T) {
 func TestWriteModelForecastIdentifiesEpochDerivedWork(t *testing.T) {
 	report := model.ResourceForecast{ApproximateParameters: 10, PlannedTokens: 1000, EpochDerivedStages: []string{"midtrain", "post-train"}}
 	var output bytes.Buffer
-	writeModelForecast(&output, report)
+	writeModelForecast(&output, report, model.HostForecast{Ready: true, Execution: training.Execution{Host: training.Host{OS: "linux", Architecture: "amd64"}}}, false)
 	for _, want := range []string{"at least 1.0K plus 2 epoch-derived stage(s)", "midtrain, post-train resolve during training preflight"} {
 		if !strings.Contains(output.String(), want) {
 			t.Fatalf("forecast output missing %q: %q", want, output.String())

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -453,7 +453,7 @@ func TestRootHelpLocksCommandVocabulary(t *testing.T) {
 		t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
 	}
 	help := stdout.String()
-	for _, want := range []string{"index", "lookaside", "model", "config"} {
+	for _, want := range []string{"status", "index", "lookaside", "model", "config"} {
 		if !strings.Contains(help, want) {
 			t.Errorf("root help does not contain %q:\n%s", want, help)
 		}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 OpenWALDO Project contributors
+// Copyright (c) 2026 CtrlIQ, Inc.
+// Copyright (c) 2026 Gregory M. Kurtzer
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/openwaldo/waldo/internal/status"
+	"github.com/openwaldo/waldo/internal/training"
+)
+
+func runStatus(context Context, _ []string, stdout, _ io.Writer) error {
+	report, err := status.Inspect(context.Execution)
+	if err != nil {
+		return err
+	}
+	if context.JSON {
+		return writeJSON(stdout, report)
+	}
+	fmt.Fprintf(stdout, "Host          %s/%s, %d CPUs\n", report.Host.OS, report.Host.Architecture, report.Host.CPUs)
+	fmt.Fprintf(stdout, "Memory        %s\n", humanBytesUint(report.Host.MemoryBytes))
+	fmt.Fprintf(stdout, "Disk          %s available / %s total\n", humanBytesUint(report.Host.DiskFree), humanBytesUint(report.Host.DiskBytes))
+	fmt.Fprintln(stdout)
+	fmt.Fprintf(stdout, "Index         %s\n", report.Index.Path)
+	fmt.Fprintf(stdout, "  Ready       %s\n", readiness(report.Index.Ready))
+	if !report.Index.Ready {
+		fmt.Fprintf(stdout, "  Reason      %s\n", report.Index.Reason)
+	}
+	fmt.Fprintf(stdout, "Lookaside     %s\n", report.Lookaside.Cache)
+	if report.Lookaside.Publish == nil {
+		fmt.Fprintln(stdout, "  Publish     (not configured)")
+	} else {
+		fmt.Fprintf(stdout, "  Publish     %s\n", report.Lookaside.Publish.URL)
+	}
+	fmt.Fprintln(stdout)
+	if report.Training.Execution == nil {
+		fmt.Fprintln(stdout, "Training      unavailable")
+	} else {
+		printTrainingExecution(stdout, *report.Training.Execution)
+	}
+	fmt.Fprintf(stdout, "  Ready       %s\n", readiness(report.Training.Ready))
+	if !report.Training.Ready {
+		fmt.Fprintf(stdout, "  Reason      %s\n", report.Training.Reason)
+	}
+	fmt.Fprintln(stdout)
+	fmt.Fprintf(stdout, "Ready         %s\n", readiness(report.Ready))
+	if !report.Ready {
+		for _, reason := range report.Reasons {
+			fmt.Fprintf(stdout, "Reason        %s\n", singleLine(reason))
+		}
+	}
+	return nil
+}
+
+func printTrainingExecution(output io.Writer, execution training.Execution) {
+	fmt.Fprintf(output, "Training      %s@%s\n", execution.Backend.Name, execution.Backend.Revision)
+	fmt.Fprintf(output, "  Runtime     %s\n", singleLine(execution.Runtime))
+	if len(execution.Accelerators) == 0 {
+		fmt.Fprintln(output, "  Accelerator CPU")
+		return
+	}
+	for index, accelerator := range execution.Accelerators {
+		label := "Accelerator"
+		if index > 0 {
+			label = ""
+		}
+		fmt.Fprintf(output, "  %-11s %s, %s\n", label, acceleratorDisplay(accelerator), humanBytesUint(accelerator.MemoryBytes))
+	}
+}
+
+func acceleratorDisplay(accelerator training.Accelerator) string {
+	manufacturer := strings.TrimSpace(accelerator.Manufacturer)
+	model := strings.TrimSpace(accelerator.Model)
+	if manufacturer == "" || strings.Contains(strings.ToLower(model), strings.ToLower(manufacturer)) {
+		return model
+	}
+	return manufacturer + " " + model
+}
+
+func readiness(ready bool) string {
+	if ready {
+		return "yes"
+	}
+	return "no"
+}
+
+func singleLine(value string) string {
+	return strings.Join(strings.Fields(value), " ")
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -22,55 +22,62 @@ func runStatus(context Context, _ []string, stdout, _ io.Writer) error {
 	if context.JSON {
 		return writeJSON(stdout, report)
 	}
-	fmt.Fprintf(stdout, "Host          %s/%s, %d CPUs\n", report.Host.OS, report.Host.Architecture, report.Host.CPUs)
-	fmt.Fprintf(stdout, "Memory        %s\n", humanBytesUint(report.Host.MemoryBytes))
-	fmt.Fprintf(stdout, "Disk          %s available / %s total\n", humanBytesUint(report.Host.DiskFree), humanBytesUint(report.Host.DiskBytes))
+	fmt.Fprintln(stdout, "Host")
+	printStatusField(stdout, "Platform", fmt.Sprintf("%s/%s", report.Host.OS, report.Host.Architecture))
+	printStatusField(stdout, "CPUs", fmt.Sprintf("%d", report.Host.CPUs))
+	printStatusField(stdout, "Memory", humanBytesUint(report.Host.MemoryBytes))
+	printStatusField(stdout, "Disk", fmt.Sprintf("%s available / %s total", humanBytesUint(report.Host.DiskFree), humanBytesUint(report.Host.DiskBytes)))
 	fmt.Fprintln(stdout)
-	fmt.Fprintf(stdout, "Index         %s\n", report.Index.Path)
-	fmt.Fprintf(stdout, "  Ready       %s\n", readiness(report.Index.Ready))
+	fmt.Fprintln(stdout, "Index")
+	printStatusField(stdout, "Path", report.Index.Path)
+	printStatusField(stdout, "Ready", readiness(report.Index.Ready))
 	if !report.Index.Ready {
-		fmt.Fprintf(stdout, "  Reason      %s\n", report.Index.Reason)
-	}
-	fmt.Fprintf(stdout, "Lookaside     %s\n", report.Lookaside.Cache)
-	if report.Lookaside.Publish == nil {
-		fmt.Fprintln(stdout, "  Publish     (not configured)")
-	} else {
-		fmt.Fprintf(stdout, "  Publish     %s\n", report.Lookaside.Publish.URL)
+		printStatusField(stdout, "Reason", report.Index.Reason)
 	}
 	fmt.Fprintln(stdout)
+	fmt.Fprintln(stdout, "Lookaside")
+	printStatusField(stdout, "Cache", report.Lookaside.Cache)
+	if report.Lookaside.Publish == nil {
+		printStatusField(stdout, "Publish", "(not configured)")
+	} else {
+		printStatusField(stdout, "Publish", report.Lookaside.Publish.URL)
+	}
+	fmt.Fprintln(stdout)
+	fmt.Fprintln(stdout, "Training")
 	if report.Training.Execution == nil {
-		fmt.Fprintln(stdout, "Training      unavailable")
+		printStatusField(stdout, "Backend", "unavailable")
 	} else {
 		printTrainingExecution(stdout, *report.Training.Execution)
 	}
-	fmt.Fprintf(stdout, "  Ready       %s\n", readiness(report.Training.Ready))
+	printStatusField(stdout, "Ready", readiness(report.Training.Ready))
 	if !report.Training.Ready {
-		fmt.Fprintf(stdout, "  Reason      %s\n", report.Training.Reason)
+		printStatusField(stdout, "Reason", report.Training.Reason)
 	}
 	fmt.Fprintln(stdout)
-	fmt.Fprintf(stdout, "Ready         %s\n", readiness(report.Ready))
+	fmt.Fprintln(stdout, "Overall")
+	printStatusField(stdout, "Ready", readiness(report.Ready))
 	if !report.Ready {
 		for _, reason := range report.Reasons {
-			fmt.Fprintf(stdout, "Reason        %s\n", singleLine(reason))
+			printStatusField(stdout, "Reason", singleLine(reason))
 		}
 	}
 	return nil
 }
 
 func printTrainingExecution(output io.Writer, execution training.Execution) {
-	fmt.Fprintf(output, "Training      %s@%s\n", execution.Backend.Name, execution.Backend.Revision)
-	fmt.Fprintf(output, "  Runtime     %s\n", singleLine(execution.Runtime))
+	printStatusField(output, "Backend", execution.Backend.Name+"@"+execution.Backend.Revision)
+	printStatusField(output, "Runtime", singleLine(execution.Runtime))
 	if len(execution.Accelerators) == 0 {
-		fmt.Fprintln(output, "  Accelerator CPU")
+		printStatusField(output, "Accelerator", "CPU")
 		return
 	}
-	for index, accelerator := range execution.Accelerators {
-		label := "Accelerator"
-		if index > 0 {
-			label = ""
-		}
-		fmt.Fprintf(output, "  %-11s %s, %s\n", label, acceleratorDisplay(accelerator), humanBytesUint(accelerator.MemoryBytes))
+	for _, accelerator := range execution.Accelerators {
+		printStatusField(output, "Accelerator", fmt.Sprintf("%s, %s", acceleratorDisplay(accelerator), humanBytesUint(accelerator.MemoryBytes)))
 	}
+}
+
+func printStatusField(output io.Writer, label, value string) {
+	fmt.Fprintf(output, "  %-11s %s\n", label, singleLine(value))
 }
 
 func acceleratorDisplay(accelerator training.Accelerator) string {

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 OpenWALDO Project contributors
+// Copyright (c) 2026 CtrlIQ, Inc.
+// Copyright (c) 2026 Gregory M. Kurtzer
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openwaldo/waldo/internal/config"
+)
+
+func TestStatusExplainsEveryUnavailableReadiness(t *testing.T) {
+	root := fixtureCLIIndex(t)
+	t.Setenv("WALDO_CONFIG", filepath.Join(t.TempDir(), "config.json"))
+	if err := config.Save(config.Config{Index: root, Model: config.Model{Backend: "fake"}}); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"status"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("status code = %d, stderr = %q", code, stderr.String())
+	}
+	for _, want := range []string{"Host", "Memory", "Index", root, "Lookaside", "Training", "Ready", "no", "Reason", "fake backend"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("status output missing %q:\n%s", want, stdout.String())
+		}
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"--json", "status"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("JSON status code = %d, stderr = %q", code, stderr.String())
+	}
+	var output struct {
+		Ready bool `json:"ready"`
+		Index struct {
+			Ready bool `json:"ready"`
+		} `json:"index"`
+		Training struct {
+			Ready  bool   `json:"ready"`
+			Reason string `json:"reason"`
+		} `json:"training"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatal(err)
+	}
+	if output.Ready || !output.Index.Ready || output.Training.Ready || output.Training.Reason == "" {
+		t.Fatalf("status = %+v", output)
+	}
+}

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -25,6 +25,11 @@ func TestStatusExplainsEveryUnavailableReadiness(t *testing.T) {
 	if code := Run([]string{"status"}, &stdout, &stderr); code != 0 {
 		t.Fatalf("status code = %d, stderr = %q", code, stderr.String())
 	}
+	for _, heading := range []string{"Host\n", "Index\n", "Lookaside\n", "Training\n", "Overall\n"} {
+		if !strings.Contains(stdout.String(), heading) {
+			t.Errorf("status output missing section %q:\n%s", heading, stdout.String())
+		}
+	}
 	for _, want := range []string{"Host", "Memory", "Index", root, "Lookaside", "Training", "Ready", "no", "Reason", "fake backend"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Errorf("status output missing %q:\n%s", want, stdout.String())

--- a/internal/host/filesystem_other.go
+++ b/internal/host/filesystem_other.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 OpenWALDO Project contributors
+// Copyright (c) 2026 CtrlIQ, Inc.
+// Copyright (c) 2026 Gregory M. Kurtzer
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux && !darwin
+
+package host
+
+import "fmt"
+
+func filesystemCapacity() (uint64, uint64, error) {
+	return 0, 0, fmt.Errorf("filesystem capacity detection is unavailable on this platform")
+}

--- a/internal/host/filesystem_unix.go
+++ b/internal/host/filesystem_unix.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 OpenWALDO Project contributors
+// Copyright (c) 2026 CtrlIQ, Inc.
+// Copyright (c) 2026 Gregory M. Kurtzer
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux || darwin
+
+package host
+
+import "golang.org/x/sys/unix"
+
+func filesystemCapacity() (uint64, uint64, error) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs("/", &stat); err != nil {
+		return 0, 0, err
+	}
+	blockSize := uint64(stat.Bsize)
+	return stat.Blocks * blockSize, stat.Bavail * blockSize, nil
+}

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 OpenWALDO Project contributors
+// Copyright (c) 2026 CtrlIQ, Inc.
+// Copyright (c) 2026 Gregory M. Kurtzer
+// SPDX-License-Identifier: Apache-2.0
+
+// Package host reports local machine resources that are independent of any
+// training framework. Accelerator and runtime facts remain owned by training.
+package host
+
+import (
+	"fmt"
+	"runtime"
+)
+
+type Facts struct {
+	OS           string `json:"os"`
+	Architecture string `json:"architecture"`
+	CPUs         int    `json:"cpus"`
+	MemoryBytes  uint64 `json:"memory_bytes"`
+	DiskBytes    uint64 `json:"disk_bytes"`
+	DiskFree     uint64 `json:"disk_free_bytes"`
+}
+
+func Inspect() (Facts, error) {
+	memory, err := physicalMemory()
+	if err != nil {
+		return Facts{}, fmt.Errorf("inspect host memory: %w", err)
+	}
+	disk, free, err := filesystemCapacity()
+	if err != nil {
+		return Facts{}, fmt.Errorf("inspect host filesystem: %w", err)
+	}
+	return Facts{
+		OS: runtime.GOOS, Architecture: runtime.GOARCH, CPUs: runtime.NumCPU(),
+		MemoryBytes: memory, DiskBytes: disk, DiskFree: free,
+	}, nil
+}

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 OpenWALDO Project contributors
+// Copyright (c) 2026 CtrlIQ, Inc.
+// Copyright (c) 2026 Gregory M. Kurtzer
+// SPDX-License-Identifier: Apache-2.0
+
+package host
+
+import "testing"
+
+func TestInspectReportsCurrentHostCapacity(t *testing.T) {
+	facts, err := Inspect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if facts.OS == "" || facts.Architecture == "" || facts.CPUs < 1 || facts.MemoryBytes == 0 || facts.DiskBytes == 0 || facts.DiskFree > facts.DiskBytes {
+		t.Fatalf("facts = %+v", facts)
+	}
+}

--- a/internal/host/memory_darwin.go
+++ b/internal/host/memory_darwin.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 OpenWALDO Project contributors
+// Copyright (c) 2026 CtrlIQ, Inc.
+// Copyright (c) 2026 Gregory M. Kurtzer
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build darwin
+
+package host
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func physicalMemory() (uint64, error) {
+	output, err := exec.Command("/usr/sbin/sysctl", "-n", "hw.memsize").Output()
+	if err != nil {
+		return 0, err
+	}
+	value, err := strconv.ParseUint(strings.TrimSpace(string(output)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse hw.memsize: %w", err)
+	}
+	return value, nil
+}

--- a/internal/host/memory_linux.go
+++ b/internal/host/memory_linux.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 OpenWALDO Project contributors
+// Copyright (c) 2026 CtrlIQ, Inc.
+// Copyright (c) 2026 Gregory M. Kurtzer
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package host
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func physicalMemory() (uint64, error) {
+	file, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 || fields[0] != "MemTotal:" {
+			continue
+		}
+		kilobytes, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parse MemTotal: %w", err)
+		}
+		return kilobytes * 1024, nil
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+	return 0, fmt.Errorf("MemTotal is absent from /proc/meminfo")
+}

--- a/internal/host/memory_other.go
+++ b/internal/host/memory_other.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 OpenWALDO Project contributors
+// Copyright (c) 2026 CtrlIQ, Inc.
+// Copyright (c) 2026 Gregory M. Kurtzer
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux && !darwin
+
+package host
+
+import "fmt"
+
+func physicalMemory() (uint64, error) {
+	return 0, fmt.Errorf("physical memory detection is unavailable on this platform")
+}

--- a/internal/model/build.go
+++ b/internal/model/build.go
@@ -53,12 +53,12 @@ type MultiNodeHandoff struct {
 	StageCount   int
 }
 
-// CheckBackend validates that this host can execute the requested portable
-// architecture and objectives before callers materialize any corpus objects.
-func (builder Builder) CheckBackend(ctx context.Context, architecture Architecture, objectives []string) error {
+// ResolveBackend selects and validates the same training harness used by a
+// build without creating model or run state.
+func (builder Builder) ResolveBackend(ctx context.Context, architecture Architecture, objectives []string) (training.Selection, error) {
 	architectureJSON, err := json.Marshal(architecture)
 	if err != nil {
-		return err
+		return training.Selection{}, err
 	}
 	resolver := builder.Resolver
 	if resolver == nil {
@@ -66,12 +66,19 @@ func (builder Builder) CheckBackend(ctx context.Context, architecture Architectu
 	}
 	selection, err := resolver.Resolve(ctx, training.ResolveRequest{Architecture: architectureJSON, Objectives: objectives})
 	if err != nil {
-		return fmt.Errorf("resolve training backend: %w", err)
+		return training.Selection{}, fmt.Errorf("resolve training backend: %w", err)
 	}
 	if err := validateSelection(selection, objectives); err != nil {
-		return err
+		return training.Selection{}, err
 	}
-	return nil
+	return selection, nil
+}
+
+// CheckBackend validates that this host can execute the requested portable
+// architecture and objectives before callers materialize any corpus objects.
+func (builder Builder) CheckBackend(ctx context.Context, architecture Architecture, objectives []string) error {
+	_, err := builder.ResolveBackend(ctx, architecture, objectives)
+	return err
 }
 
 func ValidateName(name string) error {

--- a/internal/model/host_forecast.go
+++ b/internal/model/host_forecast.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 OpenWALDO Project contributors
+// Copyright (c) 2026 CtrlIQ, Inc.
+// Copyright (c) 2026 Gregory M. Kurtzer
+// SPDX-License-Identifier: Apache-2.0
+
+package model
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openwaldo/waldo/internal/training"
+)
+
+// HostForecast compares one portable workload with the execution environment
+// selected by the same resolver used for training.
+type HostForecast struct {
+	Ready              bool               `json:"ready"`
+	Reason             string             `json:"reason,omitempty"`
+	Execution          training.Execution `json:"execution"`
+	AvailableMemory    uint64             `json:"available_memory_bytes"`
+	RequiredMemory     uint64             `json:"required_memory_bytes"`
+	ApproximateSeconds *int64             `json:"approximate_seconds,omitempty"`
+	EstimateSource     string             `json:"estimate_source,omitempty"`
+}
+
+func (builder Builder) ResolveComposeBackend(ctx context.Context, compose Compose) (training.Selection, error) {
+	plan, err := forecastPlanForCompose(compose)
+	if err != nil {
+		return training.Selection{}, err
+	}
+	return builder.ResolveBackend(ctx, plan.Architecture, planObjectives(plan))
+}
+
+func (builder Builder) ResolveIndexBackend(ctx context.Context, tokens int64) (training.Selection, error) {
+	_, plan, err := planIndexSelection(tokens)
+	if err != nil {
+		return training.Selection{}, err
+	}
+	return builder.ResolveBackend(ctx, plan.Architecture, planObjectives(plan))
+}
+
+func AssessComposeHost(compose Compose, report ResourceForecast, execution training.Execution, hostMemory uint64) (HostForecast, error) {
+	plan, err := forecastPlanForCompose(compose)
+	if err != nil {
+		return HostForecast{}, err
+	}
+	return assessHost(plan, report, execution, hostMemory)
+}
+
+func AssessIndexHost(tokens int64, report ResourceForecast, execution training.Execution, hostMemory uint64) (HostForecast, error) {
+	_, plan, err := planIndexSelection(tokens)
+	if err != nil {
+		return HostForecast{}, err
+	}
+	return assessHost(plan, report, execution, hostMemory)
+}
+
+func assessHost(plan Plan, report ResourceForecast, execution training.Execution, hostMemory uint64) (HostForecast, error) {
+	assessment := HostForecast{Execution: execution}
+	if execution.Backend.Name == training.BackendFake {
+		assessment.Reason = "the fake backend simulates training and does not produce a trainable model"
+		return assessment, nil
+	}
+	devices := len(execution.Accelerators)
+	shards := devices
+	available := hostMemory
+	if shards == 0 {
+		shards = 1
+	} else {
+		available = execution.Accelerators[0].MemoryBytes
+		for _, accelerator := range execution.Accelerators[1:] {
+			if accelerator.MemoryBytes < available {
+				available = accelerator.MemoryBytes
+			}
+		}
+	}
+	required, err := requiredMemoryPerGPU(plan, shards)
+	if err != nil {
+		return HostForecast{}, err
+	}
+	assessment.AvailableMemory = available
+	assessment.RequiredMemory = required
+	if available == 0 {
+		assessment.Reason = "WALDO could not determine available training memory on this host"
+		return assessment, nil
+	}
+	usable := available - available/10
+	if required > usable {
+		assessment.Reason = fmt.Sprintf("training requires %s per device including workspace, but this host has %s", forecastMemory(required), forecastMemory(available))
+		return assessment, nil
+	}
+	assessment.Ready = true
+	if devices == 0 || !homogeneousAccelerators(execution.Accelerators) {
+		return assessment, nil
+	}
+	key := acceleratorKey(execution.Accelerators[0].Manufacturer, execution.Accelerators[0].Model)
+	for _, configuration := range report.Configurations {
+		if configuration.GPUs != devices || acceleratorKey(configuration.Manufacturer, configuration.Accelerator) != key {
+			continue
+		}
+		seconds := configuration.ApproximateSeconds
+		assessment.ApproximateSeconds = &seconds
+		assessment.EstimateSource = configuration.EstimateSource
+		break
+	}
+	return assessment, nil
+}
+
+func homogeneousAccelerators(accelerators []training.Accelerator) bool {
+	if len(accelerators) == 0 {
+		return false
+	}
+	key := acceleratorKey(accelerators[0].Manufacturer, accelerators[0].Model)
+	for _, accelerator := range accelerators[1:] {
+		if acceleratorKey(accelerator.Manufacturer, accelerator.Model) != key {
+			return false
+		}
+	}
+	return true
+}
+
+func forecastMemory(bytes uint64) string {
+	const gibibyte = uint64(1 << 30)
+	if bytes%gibibyte == 0 {
+		return fmt.Sprintf("%d GiB", bytes/gibibyte)
+	}
+	return fmt.Sprintf("%.1f GiB", float64(bytes)/float64(gibibyte))
+}

--- a/internal/model/host_forecast.go
+++ b/internal/model/host_forecast.go
@@ -17,6 +17,7 @@ import (
 type HostForecast struct {
 	Ready              bool               `json:"ready"`
 	Reason             string             `json:"reason,omitempty"`
+	Recommendation     string             `json:"recommendation,omitempty"`
 	Execution          training.Execution `json:"execution"`
 	AvailableMemory    uint64             `json:"available_memory_bytes"`
 	RequiredMemory     uint64             `json:"required_memory_bytes"`
@@ -88,6 +89,7 @@ func assessHost(plan Plan, report ResourceForecast, execution training.Execution
 	usable := available - available/10
 	if required > usable {
 		assessment.Reason = fmt.Sprintf("training requires %s per device including workspace, but this host has %s", forecastMemory(required), forecastMemory(available))
+		assessment.Recommendation = fmt.Sprintf("use remote compute with at least %s of usable memory per device, or reduce the model, batch size, or sequence length", forecastMemory(required))
 		return assessment, nil
 	}
 	assessment.Ready = true

--- a/internal/model/host_forecast_test.go
+++ b/internal/model/host_forecast_test.go
@@ -46,7 +46,7 @@ func TestAssessComposeHostExplainsInsufficientCPUMemory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if assessment.Ready || assessment.Reason == "" || assessment.AvailableMemory != 1<<30 || assessment.RequiredMemory == 0 {
+	if assessment.Ready || assessment.Reason == "" || assessment.Recommendation == "" || assessment.AvailableMemory != 1<<30 || assessment.RequiredMemory == 0 {
 		t.Fatalf("assessment = %+v", assessment)
 	}
 }

--- a/internal/model/host_forecast_test.go
+++ b/internal/model/host_forecast_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 OpenWALDO Project contributors
+// Copyright (c) 2026 CtrlIQ, Inc.
+// Copyright (c) 2026 Gregory M. Kurtzer
+// SPDX-License-Identifier: Apache-2.0
+
+package model
+
+import (
+	"testing"
+
+	"github.com/openwaldo/waldo/internal/training"
+)
+
+func TestAssessComposeHostUsesResolvedAcceleratorAndCatalogEstimate(t *testing.T) {
+	compose := validCompose()
+	report, err := ForecastCompose(compose)
+	if err != nil {
+		t.Fatal(err)
+	}
+	execution := training.Execution{
+		Backend:      training.Identity{Name: training.BackendPyTorch, Revision: "pytorch-v1"},
+		Host:         training.Host{OS: "linux", Architecture: "amd64"},
+		Accelerators: []training.Accelerator{{Manufacturer: "NVIDIA", Model: "H100 SXM", MemoryBytes: 80 << 30}},
+		Nodes:        1, WorldSize: 1,
+	}
+	assessment, err := AssessComposeHost(compose, report, execution, 256<<30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !assessment.Ready || assessment.Reason != "" || assessment.RequiredMemory == 0 || assessment.AvailableMemory != 80<<30 || assessment.ApproximateSeconds == nil || assessment.EstimateSource != "catalog" {
+		t.Fatalf("assessment = %+v", assessment)
+	}
+}
+
+func TestAssessComposeHostExplainsInsufficientCPUMemory(t *testing.T) {
+	compose := validCompose()
+	report, err := ForecastCompose(compose)
+	if err != nil {
+		t.Fatal(err)
+	}
+	execution := training.Execution{
+		Backend: training.Identity{Name: training.BackendPyTorch, Revision: "pytorch-v1"},
+		Host:    training.Host{OS: "linux", Architecture: "amd64"}, Nodes: 1, WorldSize: 1,
+	}
+	assessment, err := AssessComposeHost(compose, report, execution, 1<<30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if assessment.Ready || assessment.Reason == "" || assessment.AvailableMemory != 1<<30 || assessment.RequiredMemory == 0 {
+		t.Fatalf("assessment = %+v", assessment)
+	}
+}
+
+func TestAssessComposeHostDoesNotTreatFakeBackendAsReady(t *testing.T) {
+	compose := validCompose()
+	report, err := ForecastCompose(compose)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assessment, err := AssessComposeHost(compose, report, training.Execution{
+		Backend: training.Identity{Name: training.BackendFake, Revision: "fake-v1"},
+		Host:    training.Host{OS: "linux", Architecture: "amd64"}, Nodes: 1, WorldSize: 1,
+	}, 256<<30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if assessment.Ready || assessment.Reason == "" {
+		t.Fatalf("assessment = %+v", assessment)
+	}
+}

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -63,6 +63,20 @@ func TestLoadComposeIsStrictAndKeepsIndexPathsLogical(t *testing.T) {
 	}
 }
 
+func TestLoadComposeExplainsMissingAndEmptyFiles(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing.yaml")
+	if _, _, err := LoadCompose(missing); err == nil || !strings.Contains(err.Error(), "model compose") || !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("missing compose error = %v", err)
+	}
+	empty := filepath.Join(t.TempDir(), "empty.yaml")
+	if err := os.WriteFile(empty, []byte(" \n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := LoadCompose(empty); err == nil || !strings.Contains(err.Error(), "model compose") || !strings.Contains(err.Error(), "is empty") {
+		t.Fatalf("empty compose error = %v", err)
+	}
+}
+
 func TestComposeConversationInteractionIsStrictAndChangesPlanIdentity(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "conversation.yaml")
 	document := strings.Replace(composeYAML(""), "architecture:\n", "interaction:\n  template: user-assistant-v1\narchitecture:\n", 1)

--- a/internal/model/presets.go
+++ b/internal/model/presets.go
@@ -87,13 +87,22 @@ func ForecastIndexSelection(tokens int64) (Preset, ResourceForecast, error) {
 }
 
 func ForecastIndexSelectionWithCalibration(tokens int64, calibrations []ForecastCalibration) (Preset, ResourceForecast, error) {
-	selected, err := RecommendedPreset(tokens)
+	selected, plan, err := planIndexSelection(tokens)
 	if err != nil {
 		return Preset{}, ResourceForecast{}, err
 	}
+	report, err := forecastPlanWithCalibration(plan, calibrations)
+	return selected, report, err
+}
+
+func planIndexSelection(tokens int64) (Preset, Plan, error) {
+	selected, err := RecommendedPreset(tokens)
+	if err != nil {
+		return Preset{}, Plan{}, err
+	}
 	architecture, err := selected.Architecture.Forecast()
 	if err != nil {
-		return Preset{}, ResourceForecast{}, err
+		return Preset{}, Plan{}, err
 	}
 	batch := int64(8)
 	sequence := int64(selected.Architecture.ContextTokens)
@@ -108,6 +117,5 @@ func ForecastIndexSelectionWithCalibration(tokens int64, calibrations []Forecast
 			Parameters: training.Parameters{Steps: steps, BatchSize: batch, SequenceLength: sequence, LearningRate: 0.0003, Seed: 42},
 		}},
 	}
-	report, err := forecastPlanWithCalibration(plan, calibrations)
-	return selected, report, err
+	return selected, plan, nil
 }

--- a/internal/model/recipe.go
+++ b/internal/model/recipe.go
@@ -375,7 +375,13 @@ func LoadCompose(path string) (Compose, string, error) {
 	}
 	data, err := os.ReadFile(absolute)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return Compose{}, "", fmt.Errorf("model compose %s does not exist", absolute)
+		}
 		return Compose{}, "", err
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return Compose{}, "", fmt.Errorf("model compose %s is empty", absolute)
 	}
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	decoder.KnownFields(true)

--- a/internal/model/resource_forecast.go
+++ b/internal/model/resource_forecast.go
@@ -25,7 +25,7 @@ type ResourceForecast struct {
 	EpochDerivedStages    []string                `json:"epoch_derived_stages,omitempty"`
 	TrainingFLOPs         float64                 `json:"training_flops"`
 	Calibrations          []ForecastCalibration   `json:"calibrations,omitempty"`
-	Configurations        []HardwareConfiguration `json:"configurations"`
+	Configurations        []HardwareConfiguration `json:"configurations,omitempty"`
 }
 
 // ForecastCalibration is aggregate, reproducible evidence from completed

--- a/internal/model/resource_forecast.go
+++ b/internal/model/resource_forecast.go
@@ -19,6 +19,7 @@ const (
 
 type ResourceForecast struct {
 	Catalog               string                  `json:"catalog"`
+	CatalogNote           string                  `json:"catalog_note,omitempty"`
 	Formula               string                  `json:"formula"`
 	ApproximateParameters uint64                  `json:"approximate_parameters"`
 	PlannedTokens         int64                   `json:"planned_tokens"`
@@ -171,7 +172,7 @@ func forecastPlanWithCalibration(plan Plan, calibrations []ForecastCalibration) 
 		}
 	}
 	if len(report.Configurations) == 0 {
-		return ResourceForecast{}, fmt.Errorf("model does not fit any hardware configuration in forecast catalog %s", forecastCatalog)
+		report.CatalogNote = fmt.Sprintf("no configuration in forecast catalog %s has sufficient memory for this workload", forecastCatalog)
 	}
 	sort.Slice(report.Configurations, func(i, j int) bool {
 		left, right := report.Configurations[i], report.Configurations[j]

--- a/internal/model/resource_forecast_test.go
+++ b/internal/model/resource_forecast_test.go
@@ -209,7 +209,7 @@ func TestLoadForecastCalibrationUsesVerifiedLocalModels(t *testing.T) {
 	}
 }
 
-func TestForecastPlanRejectsModelTooLargeForCatalog(t *testing.T) {
+func TestForecastPlanReportsModelTooLargeForCatalog(t *testing.T) {
 	architecture := Architecture{
 		Family: "decoder-transformer", ContextTokens: 2048, VocabularySize: 32000,
 		HiddenSize: 65_536, IntermediateSize: 262_144, Layers: 256,
@@ -220,11 +220,14 @@ func TestForecastPlanRejectsModelTooLargeForCatalog(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = forecastPlan(Plan{
+	report, err := forecastPlan(Plan{
 		Architecture: architecture, Forecast: forecast,
 		Stages: []PlannedStage{{Name: "pretrain", Parameters: validCompose().Stages[0].Parameters, PlannedTokens: 1}},
 	})
-	if err == nil || !strings.Contains(err.Error(), "does not fit any hardware configuration") {
-		t.Fatalf("error = %v", err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Configurations) != 0 || !strings.Contains(report.CatalogNote, "no configuration") || report.ApproximateParameters == 0 || report.PlannedTokens != 1 {
+		t.Fatalf("report = %+v", report)
 	}
 }

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 OpenWALDO Project contributors
+// Copyright (c) 2026 CtrlIQ, Inc.
+// Copyright (c) 2026 Gregory M. Kurtzer
+// SPDX-License-Identifier: Apache-2.0
+
+// Package status reports whether the current machine is ready for WALDO data
+// and model workflows without changing configuration or durable state.
+package status
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openwaldo/waldo/internal/config"
+	"github.com/openwaldo/waldo/internal/host"
+	waldoindex "github.com/openwaldo/waldo/internal/index"
+	"github.com/openwaldo/waldo/internal/model"
+	"github.com/openwaldo/waldo/internal/training"
+)
+
+type Readiness struct {
+	Ready  bool   `json:"ready"`
+	Reason string `json:"reason,omitempty"`
+}
+
+type Index struct {
+	Readiness
+	Path    string `json:"path"`
+	Managed bool   `json:"managed"`
+}
+
+type Lookaside struct {
+	Cache   string          `json:"cache"`
+	Scratch string          `json:"scratch"`
+	Publish *config.Publish `json:"publish,omitempty"`
+}
+
+type Training struct {
+	Readiness
+	Execution *training.Execution `json:"execution,omitempty"`
+}
+
+type Report struct {
+	Host      host.Facts `json:"host"`
+	Index     Index      `json:"index"`
+	Lookaside Lookaside  `json:"lookaside"`
+	Training  Training   `json:"training"`
+	Ready     bool       `json:"ready"`
+	Reasons   []string   `json:"reasons,omitempty"`
+}
+
+func Inspect(ctx context.Context) (Report, error) {
+	facts, err := host.Inspect()
+	if err != nil {
+		return Report{}, err
+	}
+	configuration, err := config.Load()
+	if err != nil {
+		return Report{}, err
+	}
+	indexRoot, managed, err := config.EffectiveIndexRoot(configuration)
+	if err != nil {
+		return Report{}, err
+	}
+	cache, err := config.EffectiveCacheRoot(configuration)
+	if err != nil {
+		return Report{}, err
+	}
+	scratch, err := config.EffectiveScratchRoot(configuration)
+	if err != nil {
+		return Report{}, err
+	}
+	report := Report{
+		Host:      facts,
+		Index:     Index{Path: indexRoot, Managed: managed},
+		Lookaside: Lookaside{Cache: cache, Scratch: scratch, Publish: configuration.Lookaside.Publish},
+	}
+	if _, err := waldoindex.ResolveConfigured(indexRoot, ""); err != nil {
+		report.Index.Reason = err.Error()
+		report.Reasons = append(report.Reasons, "index: "+err.Error())
+	} else {
+		report.Index.Ready = true
+	}
+	preset, err := model.PresetByName("10m")
+	if err != nil {
+		return Report{}, err
+	}
+	builder := model.Builder{Resolver: training.NewEnvironmentResolver(config.EffectiveModelBackend(configuration))}
+	selection, err := builder.ResolveBackend(ctx, preset.Architecture, []string{"causal-language-modeling"})
+	if err != nil {
+		report.Training.Reason = err.Error()
+		report.Reasons = append(report.Reasons, "training: "+err.Error())
+	} else {
+		report.Training.Execution = &selection.Execution
+		if selection.Execution.Backend.Name == training.BackendFake {
+			report.Training.Reason = "the fake backend simulates training and does not produce a trainable model"
+			report.Reasons = append(report.Reasons, "training: "+report.Training.Reason)
+		} else {
+			report.Training.Ready = true
+		}
+	}
+	report.Ready = report.Index.Ready && report.Training.Ready
+	if !report.Ready && len(report.Reasons) == 0 {
+		return Report{}, fmt.Errorf("status is not ready without an explanation")
+	}
+	return report, nil
+}

--- a/testing/e2e/_ingest_lifecycle.sh
+++ b/testing/e2e/_ingest_lifecycle.sh
@@ -107,6 +107,7 @@ if [ "$mode" = "recipe" ]; then
     '  name: tiny' \
     '  url: https://example.invalid/waldo-e2e' \
     '  category: public-dataset' \
+    '  content: {languages: [en]}' \
     'steps:' \
     '  - name: fetch-fixture' \
     '    exec: ./fetch-fixture.sh' \
@@ -134,7 +135,7 @@ if [ -n "${WALDO_E2E_AWS_REGION:-}" ]; then
 fi
 
 destination="$index_root/core/e2e/tiny"
-common_arguments="--title Tiny-E2E-Corpus --description Disposable-ingestion-smoke-test --license CC0-1.0 --source https://example.invalid/waldo-e2e --source-category public-dataset"
+common_arguments="--title Tiny-E2E-Corpus --description Disposable-ingestion-smoke-test --license CC0-1.0 --source https://example.invalid/waldo-e2e --source-category public-dataset --language en"
 
 if [ "$mode" = "recipe" ]; then
   retired="$recipe_root/retired.yaml"
@@ -328,8 +329,8 @@ if find "$scratch" -type f -print 2>/dev/null | grep . >/dev/null 2>&1; then
   exit 1
 fi
 cache_count=$(find "$cache" -type f -print 2>/dev/null | wc -l | tr -d ' ')
-if [ "$cache_count" -ne 1 ]; then
-  echo "verified cache contains $cache_count objects, want 1 retained object" >&2
+if [ "$cache_count" -ne 0 ]; then
+  echo "verified cache contains $cache_count objects after successful use, want 0" >&2
   exit 1
 fi
 

--- a/testing/e2e/model-fake.sh
+++ b/testing/e2e/model-fake.sh
@@ -88,6 +88,7 @@ destination="$index_root/core/e2e/model-corpus"
   --license CC0-1.0 \
   --source https://example.invalid/model-e2e \
   --source-category public-dataset \
+  --language en \
   --input-profile "$input_profile"
 
 contribution=""
@@ -138,17 +139,29 @@ EOF
 
 forecast_output=$("$binary" model forecast "$compose")
 printf '%s\n' "$forecast_output"
-printf '%s\n' "$forecast_output" | grep -q 'GPUS.*MFR.*ACCELERATOR.*MEMORY/GPU.*APPROX. TIME'
-printf '%s\n' "$forecast_output" | grep -q 'Apple.*M4 Max 40-core GPU'
-printf '%s\n' "$forecast_output" | grep -q 'NVIDIA.*H100 SXM'
-if printf '%s\n' "$forecast_output" | grep -Eq 'BACKEND|FIT|~|unified'; then
+printf '%s\n' "$forecast_output" | grep -Eq '^HOST:[[:space:]]+[^/]+/[^[:space:]]+$'
+printf '%s\n' "$forecast_output" | grep -Eq '^BACKEND:[[:space:]]+fake@'
+printf '%s\n' "$forecast_output" | grep -Eq '^READY:[[:space:]]+no$'
+printf '%s\n' "$forecast_output" | grep -q '^REASON:'
+if printf '%s\n' "$forecast_output" | grep -Eq 'HOST COMPARISON|GPUS.*MFR|FIT|~|unified'; then
   echo "forecast contains an unwanted display field" >&2
   exit 1
 fi
+comparison_output=$("$binary" model forecast "$compose" --compare-hosts)
+printf '%s\n' "$comparison_output" | grep -q 'GPUS.*MFR.*ACCELERATOR.*MEMORY/GPU.*APPROX. TIME'
+printf '%s\n' "$comparison_output" | grep -q 'Apple.*M4 Max 40-core GPU'
+printf '%s\n' "$comparison_output" | grep -q 'NVIDIA.*H100 SXM'
 [ ! -e "$models/smoke" ] || { echo "forecast created model state" >&2; exit 1; }
 forecast_json=$("$binary" --json model forecast "$compose")
 printf '%s\n' "$forecast_json" | grep -Eq '"catalog"[[:space:]]*:[[:space:]]*"openwaldo-training-hardware-'
-printf '%s\n' "$forecast_json" | grep -Eq '"approximate_seconds"[[:space:]]*:'
+printf '%s\n' "$forecast_json" | grep -Eq '"ready"[[:space:]]*:[[:space:]]*false'
+printf '%s\n' "$forecast_json" | grep -Eq '"reason"[[:space:]]*:'
+if printf '%s\n' "$forecast_json" | grep -Eq '"configurations"[[:space:]]*:'; then
+  echo "default JSON forecast exposed host comparisons" >&2
+  exit 1
+fi
+comparison_json=$("$binary" --json model forecast "$compose" --compare-hosts)
+printf '%s\n' "$comparison_json" | grep -Eq '"approximate_seconds"[[:space:]]*:'
 
 build_output=$("$binary" model train smoke "$compose" --audit)
 printf '%s\n' "$build_output"

--- a/testing/e2e/model-mlx.sh
+++ b/testing/e2e/model-mlx.sh
@@ -87,6 +87,7 @@ destination="$index_root/core/e2e/mlx"
   --description Disposable-real-MLX-training-input \
   --license CC0-1.0 \
   --source https://example.invalid/mlx-e2e \
+  --language en \
   --source-category public-dataset >/dev/null
 
 contribution=""

--- a/testing/e2e/model-pytorch.sh
+++ b/testing/e2e/model-pytorch.sh
@@ -84,6 +84,7 @@ destination="$index_root/core/e2e/pytorch"
   --description Disposable-real-PyTorch-training-input \
   --license CC0-1.0 \
   --source https://example.invalid/pytorch-e2e \
+  --language en \
   --source-category public-dataset >/dev/null
 
 contribution=""

--- a/testing/e2e/model-torchtitan-multinode.sh
+++ b/testing/e2e/model-torchtitan-multinode.sh
@@ -79,6 +79,7 @@ destination="$index_root/core/e2e/torchtitan"
   --description Disposable-multi-node-TorchTitan-input \
   --license CC0-1.0 \
   --source https://example.invalid/torchtitan-mn-e2e \
+  --language en \
   --source-category public-dataset >/dev/null
 
 contribution=""

--- a/testing/e2e/model-torchtitan.sh
+++ b/testing/e2e/model-torchtitan.sh
@@ -70,6 +70,7 @@ destination="$index_root/core/e2e/torchtitan"
   --description Disposable-real-TorchTitan-training-input \
   --license CC0-1.0 \
   --source https://example.invalid/torchtitan-e2e \
+  --language en \
   --source-category public-dataset >/dev/null
 
 contribution=""


### PR DESCRIPTION
## What changed

- add `waldo status` for host, index, lookaside, and training readiness
- make `waldo model forecast` evaluate the current host by default
- explain every `Ready: no` result and provide `--compare-hosts` for the optional hardware grid
- reuse WALDO's existing compose parser, forecast calculations, calibration data, and MLX/PyTorch/TorchTitan backend resolver
- document the CLI behavior and architecture decision

This work was inspired by [waldo-doctor](https://github.com/uradui/waldo-doctor), originally authored by [@uradui](https://github.com/uradui). Thank you for developing and sharing the host-readiness and resource-forecasting concepts that informed this integration.

## Verification

- `GOTOOLCHAIN=go1.26.5 ./testing/all.sh`
- complete Go unit and integration suite
- Go static analysis
- direct, recipe, structured-conversation, and fake-model E2E lifecycles
- real MLX train/resume/generate/export lifecycle on macOS
- status and forecast validation on Linux, including unavailable-backend explanations

## Contracts

- CLI: adds `waldo status`
- CLI: `waldo model forecast` now reports the current host by default; `--compare-hosts` restores the comparison grid
- JSON: host readiness is included; comparison configurations are omitted unless requested
- docs: adds ADR 0063 and updates CLI, architecture, and model-lifecycle documentation
- durable storage formats: none

## DCO

- [x] Every commit includes a `Signed-off-by` trailer (`git commit --signoff`).
