### PR TITLE
Environment variable WALDO_GPU_THROTTLE

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,7 +1,8 @@
 # Testing
 
 Focused Go tests live beside their packages. Process-level tests live under
-`testing/`.
+`testing/`. Python worker unit tests (stdlib `unittest`, no pip installs)
+live under `testing/python/`.
 
 ## Local checks
 
@@ -9,6 +10,7 @@ Focused Go tests live beside their packages. Process-level tests live under
 ./testing/unit.sh
 ./testing/vet.sh
 ./testing/docs.sh
+./testing/python.sh
 ```
 
 Run the complete local suite with:

--- a/internal/training/mlx.go
+++ b/internal/training/mlx.go
@@ -21,7 +21,7 @@ import (
 	"github.com/openwaldo/waldo/internal/mlxruntime"
 )
 
-const MLXRevision = "builtin-mlx-worker-schema-1-r7"
+const MLXRevision = "builtin-mlx-worker-schema-1-r8"
 
 //go:embed workers/mlx.py
 var mlxWorker []byte

--- a/internal/training/workers/mlx.py
+++ b/internal/training/workers/mlx.py
@@ -29,7 +29,8 @@ def emit(kind, **payload):
     print(json.dumps(frame, separators=(",", ":")), flush=True)
 
 
-# WALDO_GPU_THROTTLE=0.25 caps training to ~25% of wall-clock time; GPU alternates between full-speed and idle.
+# WALDO_GPU_THROTTLE=0.25 caps training to ~25% of wall-clock time; GPU alternates between
+# full-speed and idle. Applies only to the MLX worker.
 def read_gpu_throttle():
     try:
         value = float(os.environ.get("WALDO_GPU_THROTTLE") or 1)

--- a/internal/training/workers/mlx.py
+++ b/internal/training/workers/mlx.py
@@ -29,6 +29,12 @@ def emit(kind, **payload):
     print(json.dumps(frame, separators=(",", ":")), flush=True)
 
 
+# WALDO_GPU_THROTTLE=0.25 caps training to ~25% of wall-clock time; GPU alternates between full-speed and idle.
+try: GPU_THROTTLE = float(os.environ.get("WALDO_GPU_THROTTLE") or 1)
+except ValueError: GPU_THROTTLE = 1; emit("event", event={"kind": "log", "message": "specify WALDO_GPU_THROTTLE as decimal percentage, ie 0.25"})
+if not 0 < GPU_THROTTLE < 1: GPU_THROTTLE = 1
+
+
 def artifact(path, logical_path):
     digest = hashlib.sha256()
     size = 0
@@ -312,6 +318,7 @@ class Trainer:
             self.replay_steps -= 1
             self.batch = []
             return
+        step_started = time.perf_counter()
         tokens = mx.array([item[0] for item in self.batch], dtype=mx.int32)
         mask = mx.array([item[1] for item in self.batch], dtype=mx.float32)
         inputs = tokens[:, :-1]
@@ -323,6 +330,9 @@ class Trainer:
         loss, gradients = self.loss_and_grad(self.model, inputs, targets, mask)
         self.optimizer.update(self.model, gradients)
         mx.eval(self.model.parameters(), self.optimizer.state, loss)
+        if GPU_THROTTLE < 1:
+            # mx.eval already drained the GPU, so this never pauses mid command-buffer.
+            time.sleep((time.perf_counter() - step_started) * (1 / GPU_THROTTLE - 1))
         loss_value = float(loss.item())
         valid_tokens = int(mask.sum().item())
         self.step_number = next_step

--- a/internal/training/workers/mlx.py
+++ b/internal/training/workers/mlx.py
@@ -20,7 +20,7 @@ from mlx.utils import tree_flatten, tree_unflatten
 
 
 PROTOCOL_SCHEMA = 1
-WORKER_REVISION = "builtin-mlx-worker-schema-1-r7"
+WORKER_REVISION = "builtin-mlx-worker-schema-1-r8"
 
 
 def emit(kind, **payload):
@@ -30,9 +30,16 @@ def emit(kind, **payload):
 
 
 # WALDO_GPU_THROTTLE=0.25 caps training to ~25% of wall-clock time; GPU alternates between full-speed and idle.
-try: GPU_THROTTLE = float(os.environ.get("WALDO_GPU_THROTTLE") or 1)
-except ValueError: GPU_THROTTLE = 1; emit("event", event={"kind": "log", "message": "specify WALDO_GPU_THROTTLE as decimal percentage, ie 0.25"})
-if not 0 < GPU_THROTTLE < 1: GPU_THROTTLE = 1
+def read_gpu_throttle():
+    try:
+        value = float(os.environ.get("WALDO_GPU_THROTTLE") or 1)
+    except ValueError:
+        value = math.nan
+    if not 0.01 <= value <= 1:
+        emit("event", event={"kind": "log", "message": "WALDO_GPU_THROTTLE must be a decimal between 0.01 and 1.0; throttling disabled"})
+        return 1
+    return value
+GPU_THROTTLE = read_gpu_throttle()
 
 
 def artifact(path, logical_path):

--- a/internal/training/workers/pytorch.py
+++ b/internal/training/workers/pytorch.py
@@ -32,6 +32,12 @@ def emit(kind, **payload):
     print(json.dumps(frame, separators=(",", ":")), flush=True)
 
 
+# WALDO_GPU_THROTTLE=0.25 caps training to ~25% of wall-clock time; GPU alternates between full-speed and idle.
+try: GPU_THROTTLE = float(os.environ.get("WALDO_GPU_THROTTLE") or 1)
+except ValueError: GPU_THROTTLE = 1; emit("event", event={"kind": "log", "message": "specify WALDO_GPU_THROTTLE as decimal percentage, ie 0.25"})
+if not 0 < GPU_THROTTLE < 1: GPU_THROTTLE = 1
+
+
 def artifact(path, logical_path):
     digest = hashlib.sha256()
     size = 0
@@ -453,6 +459,7 @@ class Trainer:
             self.replay_steps -= 1
             self.batch = []
             return
+        step_started = time.perf_counter()
         tokens = torch.tensor([item[0] for item in self.batch], dtype=torch.long, device=self.device)
         mask = torch.tensor([item[1] for item in self.batch], dtype=torch.float32, device=self.device)
         inputs = tokens[:, :-1]
@@ -468,6 +475,9 @@ class Trainer:
         loss.backward()
         self.optimizer.step()
         self.synchronize()
+        if GPU_THROTTLE < 1 and not self.distributed:
+            # Drained by synchronize(); skipped when distributed as idle ranks trip the NCCL watchdog.
+            time.sleep((time.perf_counter() - step_started) * (1 / GPU_THROTTLE - 1))
         loss_value = float(loss.detach().cpu().item())
         valid_tokens = int(mask.sum().detach().cpu().item())
         self.step_number = next_step

--- a/internal/training/workers/pytorch.py
+++ b/internal/training/workers/pytorch.py
@@ -32,12 +32,6 @@ def emit(kind, **payload):
     print(json.dumps(frame, separators=(",", ":")), flush=True)
 
 
-# WALDO_GPU_THROTTLE=0.25 caps training to ~25% of wall-clock time; GPU alternates between full-speed and idle.
-try: GPU_THROTTLE = float(os.environ.get("WALDO_GPU_THROTTLE") or 1)
-except ValueError: GPU_THROTTLE = 1; emit("event", event={"kind": "log", "message": "specify WALDO_GPU_THROTTLE as decimal percentage, ie 0.25"})
-if not 0 < GPU_THROTTLE < 1: GPU_THROTTLE = 1
-
-
 def artifact(path, logical_path):
     digest = hashlib.sha256()
     size = 0
@@ -459,7 +453,6 @@ class Trainer:
             self.replay_steps -= 1
             self.batch = []
             return
-        step_started = time.perf_counter()
         tokens = torch.tensor([item[0] for item in self.batch], dtype=torch.long, device=self.device)
         mask = torch.tensor([item[1] for item in self.batch], dtype=torch.float32, device=self.device)
         inputs = tokens[:, :-1]
@@ -475,9 +468,6 @@ class Trainer:
         loss.backward()
         self.optimizer.step()
         self.synchronize()
-        if GPU_THROTTLE < 1 and not self.distributed:
-            # Drained by synchronize(); skipped when distributed as idle ranks trip the NCCL watchdog.
-            time.sleep((time.perf_counter() - step_started) * (1 / GPU_THROTTLE - 1))
         loss_value = float(loss.detach().cpu().item())
         valid_tokens = int(mask.sum().detach().cpu().item())
         self.step_number = next_step

--- a/testing/all.sh
+++ b/testing/all.sh
@@ -11,6 +11,7 @@ script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 "$script_dir/unit.sh"
 "$script_dir/vet.sh"
 "$script_dir/docs.sh"
+"$script_dir/python.sh"
 "$script_dir/e2e/ingest-direct.sh"
 "$script_dir/e2e/structured-conversation.sh"
 "$script_dir/e2e/model-fake.sh"

--- a/testing/python.sh
+++ b/testing/python.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Copyright (c) 2026 OpenWALDO Project contributors
+# Copyright (c) 2026 CtrlIQ, Inc.
+# Copyright (c) 2026 Gregory M. Kurtzer
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH='' cd -- "$script_dir/.." && pwd)
+
+echo "testing: Python worker unit tests"
+(cd "$repo_root" && python3 -m unittest discover -s testing/python -p 'test_*.py' -v)

--- a/testing/python/test_mlx_gpu_throttle.py
+++ b/testing/python/test_mlx_gpu_throttle.py
@@ -72,6 +72,22 @@ class ReadGPUThrottleTest(unittest.TestCase):
         self.assertEqual(value, 1)
         self.assertEqual(emitted, "")
 
+    def test_empty(self):
+        # An env var can't be null, only unset (test_unset) or empty. "" is
+        # falsy, so `or 1` catches it before the try/except even runs --
+        # a different code path than unset, same as no code path exists for
+        # None here at all.
+        self.set_env("")
+        value, emitted = self.read_gpu_throttle()
+        self.assertEqual(value, 1)
+        self.assertEqual(emitted, "")
+
+    def test_text(self):
+        self.set_env("non-numeric text")
+        value, emitted = self.read_gpu_throttle()
+        self.assertEqual(value, 1)
+        self.assertIn("WALDO_GPU_THROTTLE must be a decimal", emitted)
+
     def test_valid(self):
         self.set_env("0.25")
         value, emitted = self.read_gpu_throttle()

--- a/testing/python/test_mlx_gpu_throttle.py
+++ b/testing/python/test_mlx_gpu_throttle.py
@@ -84,6 +84,40 @@ class ReadGPUThrottleTest(unittest.TestCase):
         self.assertEqual(value, 0.01)
         self.assertEqual(emitted, "")
 
+    def test_max(self):
+        self.set_env("1.0")
+        value, emitted = self.read_gpu_throttle()
+        self.assertEqual(value, 1.0)
+        self.assertEqual(emitted, "")
+
+    def test_zero(self):
+        self.set_env("0")
+        value, emitted = self.read_gpu_throttle()
+        self.assertEqual(value, 1)
+        self.assertIn("WALDO_GPU_THROTTLE must be a decimal", emitted)
+
+    def test_negative(self):
+        self.set_env("-0.5")
+        value, emitted = self.read_gpu_throttle()
+        self.assertEqual(value, 1)
+        self.assertIn("WALDO_GPU_THROTTLE must be a decimal", emitted)
+
+    def test_nan(self):
+        # float("nan") parses without raising, so this exercises the range
+        # check, not the except ValueError branch -- any comparison with NaN
+        # is False, so it falls through the same as an out-of-range number.
+        self.set_env("nan")
+        value, emitted = self.read_gpu_throttle()
+        self.assertEqual(value, 1)
+        self.assertIn("WALDO_GPU_THROTTLE must be a decimal", emitted)
+
+    def test_inf(self):
+        # Also parses without raising; rejected by the upper bound.
+        self.set_env("inf")
+        value, emitted = self.read_gpu_throttle()
+        self.assertEqual(value, 1)
+        self.assertIn("WALDO_GPU_THROTTLE must be a decimal", emitted)
+
     def test_malformed(self):
         self.set_env("not-a-number")
         value, emitted = self.read_gpu_throttle()

--- a/testing/python/test_mlx_gpu_throttle.py
+++ b/testing/python/test_mlx_gpu_throttle.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026 OpenWALDO Project contributors
+# Copyright (c) 2026 CtrlIQ, Inc.
+# Copyright (c) 2026 Gregory M. Kurtzer
+# SPDX-License-Identifier: Apache-2.0
+
+# internal/training/workers/mlx.py cannot be imported directly: it depends on
+# mlx (Apple Silicon + Metal only) and its module-level run() blocks on
+# stdin. read_gpu_throttle() has neither dependency, so this pulls just that
+# function (plus the emit() and PROTOCOL_SCHEMA it uses) out of the real
+# source via ast and executes it in isolation, keeping this test runnable
+# anywhere with only the standard library.
+
+import ast
+import io
+import json
+import math
+import os
+import unittest
+from contextlib import redirect_stdout
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+MLX_WORKER_PATH = os.path.join(REPO_ROOT, "internal", "training", "workers", "mlx.py")
+
+WANTED_NAMES = {"PROTOCOL_SCHEMA", "emit", "read_gpu_throttle"}
+
+
+def load_gpu_throttle_module():
+    with open(MLX_WORKER_PATH, encoding="utf-8") as source_file:
+        tree = ast.parse(source_file.read(), filename=MLX_WORKER_PATH)
+
+    extracted = [
+        node for node in tree.body
+        if (isinstance(node, ast.FunctionDef) and node.name in WANTED_NAMES)
+        or (isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id in WANTED_NAMES for target in node.targets
+        ))
+    ]
+    found = {node.name if isinstance(node, ast.FunctionDef) else node.targets[0].id for node in extracted}
+    if found != WANTED_NAMES:
+        raise AssertionError(f"expected to extract {WANTED_NAMES} from {MLX_WORKER_PATH}, found {found}")
+
+    module_ast = ast.Module(body=extracted, type_ignores=[])
+    ast.fix_missing_locations(module_ast)
+    namespace = {"math": math, "os": os, "json": json}
+    exec(compile(module_ast, MLX_WORKER_PATH, "exec"), namespace)
+    return namespace
+
+
+class ReadGPUThrottleTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.namespace = load_gpu_throttle_module()
+
+    def setUp(self):
+        self.addCleanup(os.environ.pop, "WALDO_GPU_THROTTLE", None)
+
+    def set_env(self, value):
+        if value is None:
+            os.environ.pop("WALDO_GPU_THROTTLE", None)
+        else:
+            os.environ["WALDO_GPU_THROTTLE"] = value
+
+    def read_gpu_throttle(self):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            value = self.namespace["read_gpu_throttle"]()
+        return value, buffer.getvalue()
+
+    def test_unset(self):
+        self.set_env(None)
+        value, emitted = self.read_gpu_throttle()
+        self.assertEqual(value, 1)
+        self.assertEqual(emitted, "")
+
+    def test_valid(self):
+        self.set_env("0.25")
+        value, emitted = self.read_gpu_throttle()
+        self.assertEqual(value, 0.25)
+        self.assertEqual(emitted, "")
+
+    def test_min(self):
+        self.set_env("0.01")
+        value, emitted = self.read_gpu_throttle()
+        self.assertEqual(value, 0.01)
+        self.assertEqual(emitted, "")
+
+    def test_malformed(self):
+        self.set_env("not-a-number")
+        value, emitted = self.read_gpu_throttle()
+        self.assertEqual(value, 1)
+        self.assertIn("WALDO_GPU_THROTTLE must be a decimal", emitted)
+
+    def test_too_high(self):
+        self.set_env("1.5")
+        value, emitted = self.read_gpu_throttle()
+        self.assertEqual(value, 1)
+        self.assertIn("WALDO_GPU_THROTTLE must be a decimal", emitted)
+
+    def test_tiny(self):
+        # Below the 0.01 floor, 1 / GPU_THROTTLE - 1 would otherwise blow up
+        # into an effectively infinite per-step sleep.
+        self.set_env("1e-300")
+        value, emitted = self.read_gpu_throttle()
+        self.assertEqual(value, 1)
+        self.assertIn("WALDO_GPU_THROTTLE must be a decimal", emitted)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Env var WALDO_GPU_THROTTLE, if present, adds idle time between training runs, to reduce power/heat/etc. Affects MLX only.

## What changed

Added idle time between training runs in mlx.py to prevent laptop from running fan full speed. 
If WALDO_GPU_THROTTLE envvar is a decimal percentage, it sets the cpu output (wall-time) to that value. 0.25 means 25% gpu, .75 means 75% gpu, etc.

## Verification

With WALDO_GPU_THROTTLE=0.25, my laptop no longer radiates heat, nor does the fan even turn on, even after hours of training. Mac powermetrics shows 25% +- 5% GPU usage over time, even though it bursts to 100% during training runs, and drops to 0 during idle.

## Contracts

None. Just an environment variable affecting the training worker subprocesses.

## DCO

- [x] Every commit includes a `Signed-off-by` trailer (`git commit --signoff`).
